### PR TITLE
Sync GPUix engine fixes, accessibility, and runtime recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -575,6 +575,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +893,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +926,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -933,6 +973,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1009,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1027,6 +1076,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -1272,6 +1331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1944,6 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,8 +2158,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2112,6 +2188,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -2206,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2293,6 +2370,7 @@ dependencies = [
  "napi-derive",
  "parking_lot",
  "pulldown-cmark",
+ "reqwest_client",
  "rustc-hash 2.1.3",
  "serde",
  "serde_json",
@@ -2303,12 +2381,13 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "block",
@@ -2331,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2377,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2423,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2434,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2447,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "schemars",
  "serde",
@@ -2457,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "log",
@@ -2467,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2491,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2517,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -2539,7 +2618,26 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-numerics 0.2.0",
- "windows-registry",
+ "windows-registry 0.5.3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2710,9 +2808,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2727,6 +2838,78 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "url",
+]
+
+[[package]]
+name = "http_client_tls"
+version = "0.1.0"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
+dependencies = [
+ "rustls",
+ "rustls-platform-verifier",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2957,6 +3140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3228,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3274,6 +3479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lyon"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -3431,6 +3642,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3671,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4067,6 +4305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,7 +4414,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "collections",
  "serde",
@@ -4542,6 +4786,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,6 +4884,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4619,6 +4930,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4810,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "derive_refineable",
 ]
@@ -4851,6 +5177,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest_client"
+version = "0.1.0"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "gpui_util",
+ "http_client",
+ "http_client_tls",
+ "log",
+ "regex",
+ "tokio",
+ "zed-reqwest",
+]
+
+[[package]]
 name = "resvg"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4874,6 +5217,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4945,6 +5302,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4996,9 +5439,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "async-task",
  "backtrace",
@@ -5077,6 +5529,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -5222,7 +5697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5356,6 +5831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5433,7 +5918,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "heapless",
  "log",
@@ -5571,6 +6056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5621,6 +6115,27 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5823,6 +6338,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5915,6 +6480,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5971,6 +6563,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -6103,6 +6701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6156,7 +6760,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "perf",
  "quote",
@@ -6281,6 +6885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,6 +6961,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6477,6 +7103,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.9",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6713,7 +7357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6781,7 +7425,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6910,6 +7554,17 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
@@ -6925,7 +7580,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6948,6 +7603,15 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
@@ -6966,11 +7630,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6984,18 +7666,50 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7027,9 +7741,27 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7038,10 +7770,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -7050,10 +7800,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7062,16 +7836,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7409,6 +8213,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed-reqwest"
+version = "0.12.15-zed"
+source = "git+https://github.com/zed-industries/reqwest.git?rev=c15662463bda39148ba154100dd44d3fba5873a4#c15662463bda39148ba154100dd44d3fba5873a4"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "windows-registry 0.4.0",
+]
+
+[[package]]
 name = "zed-scap"
 version = "0.0.8-zed"
 source = "git+https://github.com/zed-industries/scap?rev=4afea48c3b002197176fb19cd0f9b180dd36eaac#4afea48c3b002197176fb19cd0f9b180dd36eaac"
@@ -7545,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7562,7 +8415,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -7573,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/remorses/zed.git?rev=8b94defe56992b3ca4ffd4853ace741d8168111a#8b94defe56992b3ca4ffd4853ace741d8168111a"
+source = "git+https://github.com/remorses/zed.git?rev=1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9#1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9"
 
 [[package]]
 name = "zune-core"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ for this runtime going forward: bindings for other frameworks and platforms
 (React, Svelte, Solid, and eventually mobile hosts) will be published there as they
 land.
 
+The upstream baseline and subsequent ports are tracked in [the GPUix synchronization record](docs/upstream-sync.md).
+
 ## Install
 
 ```bash

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,6 +6,10 @@ Portions of `crates/gpui-core` are adapted from the native renderer in
 [remorses/gpuix](https://github.com/remorses/gpuix), commit
 `b8bbff4ef0dc00dc24c3d3f3ca47818e1be15c69`.
 
+Selected subsequent changes are incorporated through the review checkpoint in
+[`docs/upstream-sync.md`](docs/upstream-sync.md). The original import revision
+above is retained for provenance.
+
 The upstream native package declares the Apache License 2.0. The port retains
 the native algorithms and component implementations while replacing the
 React-facing identity and host integration with gpui-vue's Vue renderer.

--- a/crates/gpui-core/Cargo.toml
+++ b/crates/gpui-core/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.22"
 csscolorparser = "0.8.3"
 env_logger = "0.11"
 futures = "0.3"
-gpui = { git = "https://github.com/remorses/zed.git", rev = "8b94defe56992b3ca4ffd4853ace741d8168111a", default-features = false, features = [
+gpui = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9", default-features = false, features = [
   "profiler",
 ] }
 log = "0.4"
@@ -28,11 +28,12 @@ unicode-segmentation = "1"
 web-time = "1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-gpui = { git = "https://github.com/remorses/zed.git", rev = "8b94defe56992b3ca4ffd4853ace741d8168111a", default-features = false, features = [
+reqwest_client = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9" }
+gpui = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9", default-features = false, features = [
   "font-kit",
   "profiler",
 ] }
-gpui_platform = { git = "https://github.com/remorses/zed.git", rev = "8b94defe56992b3ca4ffd4853ace741d8168111a", default-features = false, features = [
+gpui_platform = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9", default-features = false, features = [
   "font-kit",
   "wayland",
   "x11",
@@ -47,15 +48,18 @@ syntect = { version = "5.3", default-features = false, features = ["regex-fancy"
 two-face = { version = "0.5.2", default-features = false, features = ["syntect-fancy"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-gpui_platform = { git = "https://github.com/remorses/zed.git", rev = "8b94defe56992b3ca4ffd4853ace741d8168111a", default-features = false }
+gpui_platform = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9", default-features = false }
 js-sys = "0.3"
 wasm-bindgen = "=0.2.127"
 web-sys = { version = "0.3", features = ["Navigator", "Window"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-gpui_macos = { git = "https://github.com/remorses/zed.git", rev = "8b94defe56992b3ca4ffd4853ace741d8168111a", default-features = false, features = [
+gpui_macos = { git = "https://github.com/remorses/zed.git", rev = "1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9", default-features = false, features = [
   "font-kit",
 ] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_HiDpi"] }
 
 [features]
 default = []

--- a/crates/gpui-core/src/accessibility.rs
+++ b/crates/gpui-core/src/accessibility.rs
@@ -1,0 +1,229 @@
+//! GPUI accessibility props from framework custom props.
+//!
+//! A node reaches AccessKit only with both an `.id(...)` and a `.role(...)`.
+//! GPUI Native already sets the id. This module sets the role and ARIA fields.
+//! Prop names match React DOM: `aria-label`, not `ariaLabel`.
+
+use std::collections::HashMap;
+
+use gpui::prelude::*;
+use gpui::{AccessibleAction, Role};
+
+use crate::element_tree::EventPayload;
+use crate::renderer::{EventCallback, emit_event_full};
+
+/// Apply `role` and `aria-*` from the adapter, plus a default role when the app
+/// did not set one. `none` / `presentation` produce no node.
+pub(crate) fn apply_accessibility<E>(
+    mut el: E,
+    props: &HashMap<String, serde_json::Value>,
+    default_role: Option<Role>,
+) -> E
+where
+    E: StatefulInteractiveElement,
+{
+    let explicit = props.get("role").and_then(|value| value.as_str());
+    if matches!(explicit, Some("none" | "presentation")) {
+        return el;
+    }
+
+    let role = explicit
+        .and_then(role_from_aria)
+        .or(default_role)
+        .filter(|role| *role != Role::GenericContainer);
+    let Some(role) = role else {
+        return el;
+    };
+    el = el.role(role);
+
+    if let Some(id) = string_prop(props, "aria-id") {
+        el = el.accessibility_id(id);
+    }
+    if let Some(label) = string_prop(props, "aria-label") {
+        el = el.aria_label(label);
+    }
+    if let Some(description) = string_prop(props, "aria-description") {
+        el = el.aria_description(description);
+    }
+    if let Some(value) = string_prop(props, "aria-valuetext") {
+        el = el.aria_value(value);
+    }
+    if let Some(expanded) = bool_prop(props, "aria-expanded") {
+        el = el.aria_expanded(expanded);
+    }
+    if let Some(selected) = bool_prop(props, "aria-selected") {
+        el = el.aria_selected(selected);
+    }
+    if let Some(level) = usize_prop(props, "aria-level") {
+        el = el.aria_level(level);
+    }
+    el
+}
+
+/// `aria-label`, or `alt` when that is empty. Used by `<img>`.
+pub(crate) fn apply_image_label<E>(
+    el: E,
+    props: &HashMap<String, serde_json::Value>,
+    alt: &str,
+) -> E
+where
+    E: StatefulInteractiveElement,
+{
+    if string_prop(props, "aria-label").is_some() || alt.is_empty() {
+        return el;
+    }
+    el.aria_label(alt.to_string())
+}
+
+/// `VoiceOver` Press. GPUI auto-adds Click only for `.on_click()`. GPUI Native
+/// click is `on_mouse_up`, so register the action by hand and emit the
+/// same JS `click` event.
+pub(crate) fn apply_a11y_click<E>(
+    el: E,
+    events: &crate::retained_tree::EventSet,
+    element_id: u64,
+    callback: Option<&EventCallback>,
+) -> E
+where
+    E: StatefulInteractiveElement,
+{
+    if !events.contains("click") {
+        return el;
+    }
+    let callback = callback.cloned();
+    el.on_a11y_action(AccessibleAction::Click, move |_data, _window, _cx| {
+        emit_event_full(
+            &callback,
+            element_id,
+            "click",
+            |payload: &mut EventPayload| {
+                payload.button = Some(0);
+                payload.click_count = Some(1);
+                payload.is_right_click = Some(false);
+            },
+        );
+    })
+}
+
+fn string_prop(props: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+    props
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+fn bool_prop(props: &HashMap<String, serde_json::Value>, key: &str) -> Option<bool> {
+    props.get(key).and_then(serde_json::Value::as_bool)
+}
+
+fn usize_prop(props: &HashMap<String, serde_json::Value>, key: &str) -> Option<usize> {
+    props
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|value| *value > 0)
+}
+
+/// ARIA token → AccessKit role. Unknown tokens are ignored, like a bad style.
+fn role_from_aria(token: &str) -> Option<Role> {
+    Some(match token {
+        "alert" => Role::Alert,
+        "alertdialog" => Role::AlertDialog,
+        "application" => Role::Application,
+        "article" => Role::Article,
+        "banner" => Role::Banner,
+        "blockquote" => Role::Blockquote,
+        "button" => Role::Button,
+        "caption" => Role::Caption,
+        "cell" => Role::Cell,
+        "checkbox" => Role::CheckBox,
+        "code" => Role::Code,
+        "columnheader" => Role::ColumnHeader,
+        "combobox" => Role::ComboBox,
+        "complementary" => Role::Complementary,
+        "contentinfo" => Role::ContentInfo,
+        "definition" => Role::Definition,
+        "deletion" => Role::ContentDeletion,
+        "dialog" => Role::Dialog,
+        "document" => Role::Document,
+        "emphasis" => Role::Emphasis,
+        "feed" => Role::Feed,
+        "figure" => Role::Figure,
+        "form" => Role::Form,
+        "generic" | "none" | "presentation" | "subscript" | "superscript" => Role::GenericContainer,
+        "grid" => Role::Grid,
+        "gridcell" => Role::GridCell,
+        "group" => Role::Group,
+        "heading" => Role::Heading,
+        "img" => Role::Image,
+        "insertion" => Role::ContentInsertion,
+        "link" => Role::Link,
+        "list" => Role::List,
+        "listbox" => Role::ListBox,
+        "listitem" => Role::ListItem,
+        "log" => Role::Log,
+        "main" => Role::Main,
+        "marquee" => Role::Marquee,
+        "math" => Role::Math,
+        "menu" => Role::Menu,
+        "menubar" => Role::MenuBar,
+        "menuitem" => Role::MenuItem,
+        "menuitemcheckbox" => Role::MenuItemCheckBox,
+        "menuitemradio" => Role::MenuItemRadio,
+        "meter" => Role::Meter,
+        "navigation" => Role::Navigation,
+        "note" => Role::Note,
+        "option" => Role::ListBoxOption,
+        "paragraph" => Role::Paragraph,
+        "progressbar" => Role::ProgressIndicator,
+        "radio" => Role::RadioButton,
+        "radiogroup" => Role::RadioGroup,
+        "region" => Role::Region,
+        "row" => Role::Row,
+        "rowgroup" => Role::RowGroup,
+        "rowheader" => Role::RowHeader,
+        "scrollbar" => Role::ScrollBar,
+        "search" => Role::Search,
+        "searchbox" => Role::SearchInput,
+        "separator" => Role::Splitter,
+        "slider" => Role::Slider,
+        "spinbutton" => Role::SpinButton,
+        "status" => Role::Status,
+        "strong" => Role::Strong,
+        "switch" => Role::Switch,
+        "tab" => Role::Tab,
+        "table" => Role::Table,
+        "tablist" => Role::TabList,
+        "tabpanel" => Role::TabPanel,
+        "term" => Role::Term,
+        "textbox" => Role::TextInput,
+        "time" => Role::Time,
+        "timer" => Role::Timer,
+        "toolbar" => Role::Toolbar,
+        "tooltip" => Role::Tooltip,
+        "tree" => Role::Tree,
+        "treegrid" => Role::TreeGrid,
+        "treeitem" => Role::TreeItem,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::role_from_aria;
+    use gpui::Role;
+
+    #[test]
+    fn maps_common_aria_tokens() {
+        assert_eq!(role_from_aria("button"), Some(Role::Button));
+        assert_eq!(role_from_aria("heading"), Some(Role::Heading));
+        assert_eq!(role_from_aria("textbox"), Some(Role::TextInput));
+        assert_eq!(role_from_aria("img"), Some(Role::Image));
+        assert_eq!(role_from_aria("option"), Some(Role::ListBoxOption));
+        assert_eq!(role_from_aria("none"), Some(Role::GenericContainer));
+        assert_eq!(role_from_aria("presentation"), Some(Role::GenericContainer));
+        assert_eq!(role_from_aria("Button"), None);
+        assert_eq!(role_from_aria("not-a-role"), None);
+    }
+}

--- a/crates/gpui-core/src/app_menu.rs
+++ b/crates/gpui-core/src/app_menu.rs
@@ -2,14 +2,14 @@
 //!
 //! GPUI never installs a main menu on its own, so `NSApp.mainMenu` stays nil
 //! and macOS paints an empty menu bar. Worse, the standard key equivalents that
-//! AppKit only provides through menu items are missing too, so a gpui-vue app
+//! `AppKit` only provides through menu items are missing too, so a gpui-vue app
 //! cannot be quit with cmd-q, hidden with cmd-h, or minimized with cmd-m.
 //!
 //! `gpui::App::set_menus` reads the key equivalent for each item out of the
 //! keymap, so [`init`] must bind the keys before it sets the menus.
 //!
 //! There is deliberately no Edit menu. A menu key equivalent is consumed by
-//! AppKit before the window sees the key event, so an Edit menu carrying cmd-c
+//! `AppKit` before the window sees the key event, so an Edit menu carrying cmd-c
 //! would take the keystroke away from the window listener that
 //! `crate::text::paint` installs for text selection, and from the per-focus
 //! clipboard handling in `custom_elements::input`.

--- a/crates/gpui-core/src/custom_elements/anchored.rs
+++ b/crates/gpui-core/src/custom_elements/anchored.rs
@@ -307,19 +307,16 @@ impl CustomElement for AnchoredElement {
             .flex_col();
         content = crate::automation::track_own_bounds(content, ctx.id);
         content = super::wire_standard_events(content, &ctx);
+        content = crate::accessibility::apply_accessibility(content, ctx.props, None);
         if let Some(style) = ctx.style {
             content = crate::renderer::apply_interactive_styles(content, style);
         }
         // Deferred overlays paint over the window blur. A missing fill lets the
         // page show through the card. Force an opaque surface when JS omitted one.
-        let has_fill = ctx.style.is_some_and(|style| {
-            style
-                .background_color
-                .as_deref()
-                .or(style.background.as_deref())
-                .and_then(crate::color::parse_color_rgba)
-                .is_some_and(|color| color.a > 0.0)
-        });
+        let has_fill = ctx
+            .style
+            .and_then(crate::style::StyleDesc::resolved_background)
+            .is_some_and(|background| !background.is_transparent());
         if !has_fill {
             content = content.bg(gpui::rgb(0x1A1A1A));
         }

--- a/crates/gpui-core/src/custom_elements/img.rs
+++ b/crates/gpui-core/src/custom_elements/img.rs
@@ -1,8 +1,13 @@
 /// Image custom elements for raster images and tintable SVG icons.
 ///
-/// This provides a native `<img>` for gpui-vue apps while keeping the same
+/// This provides a native `<img>` for GPUI Native apps while keeping the same
 /// custom-element prop pipeline (`setCustomProp`/`custom_props`).
+///
+/// HTTP(S) `src` is a GPUI URI resource. GPUI fetches it through the app
+/// `HttpClient` on a background task and paints once decode finishes. A
+/// definite `width` and `height` keep the layout box stable during that load.
 use super::{CustomElement, CustomElementFactory, CustomRenderContext};
+use base64::Engine as _;
 
 pub struct ImgFactory;
 
@@ -61,12 +66,108 @@ impl ImgObjectFit {
 }
 
 #[derive(Debug, Clone, Default)]
+enum ImgSource {
+    #[default]
+    Empty,
+    Path(std::path::PathBuf),
+    Uri(gpui::SharedUri),
+    Data(std::sync::Arc<gpui::Image>),
+    Invalid,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct ImgElement {
-    src: String,
+    source: ImgSource,
     object_fit: ImgObjectFit,
+    alt: String,
+}
+
+impl ImgElement {
+    fn load_src(&mut self, src: &str) {
+        let src = src.trim();
+        self.source = if src.is_empty() {
+            ImgSource::Empty
+        } else if src.starts_with("data:") {
+            // TODO: Replace JSON data URLs with binary mutations to keep base64 decoding off paint.
+            decode_image_data_url(src).map_or(ImgSource::Invalid, |(format, bytes)| {
+                ImgSource::Data(std::sync::Arc::new(gpui::Image::from_bytes(format, bytes)))
+            })
+        } else if let Some(uri) = http_image_uri(src) {
+            ImgSource::Uri(uri)
+        } else {
+            ImgSource::Path(src.into())
+        };
+    }
+}
+
+fn http_image_uri(src: &str) -> Option<gpui::SharedUri> {
+    let scheme_end = src.find("://")?;
+    let scheme = &src[..scheme_end];
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return None;
+    }
+    (src.len() > scheme_end + 3).then(|| gpui::SharedUri::from(src.to_string()))
+}
+
+/// Install the GPUI HTTP client so `<img src="https://…">` can fetch.
+///
+/// Web already gets `fetch` from `gpui_platform::single_threaded_web`. Desktop
+/// Application defaults to `NullHttpClient`, which fails every URI load.
+pub fn init(cx: &mut gpui::App) {
+    #[cfg(not(target_family = "wasm"))]
+    match reqwest_client::ReqwestClient::user_agent("gpui-native") {
+        Ok(client) => cx.set_http_client(std::sync::Arc::new(client)),
+        Err(error) => log::error!(
+            "GPUI Native HTTP client failed to start; <img src=\"http…\"> will not load: {error:#}"
+        ),
+    }
+    #[cfg(target_family = "wasm")]
+    let _ = cx;
+}
+
+#[cfg(test)]
+mod uri_tests {
+    use super::http_image_uri;
+
+    #[test]
+    fn only_http_urls_become_uri_sources() {
+        assert!(http_image_uri("https://example.test/a.png").is_some());
+        assert!(http_image_uri("HTTP://localhost:9/a.png").is_some());
+        assert!(http_image_uri("HTTPS://example.test/a.png").is_some());
+        assert!(http_image_uri("/tmp/a.png").is_none());
+        assert!(http_image_uri("data:image/png;base64,xx").is_none());
+        assert!(http_image_uri("file:///tmp/a.png").is_none());
+        assert!(http_image_uri("https://").is_none());
+        assert!(http_image_uri("http://").is_none());
+    }
+}
+
+fn img_fallback(ctx: &CustomRenderContext, alt: &str, message: &str) -> gpui::AnyElement {
+    use gpui::prelude::*;
+
+    let mut fallback = super::custom_surface(
+        gpui::div()
+            .id(super::custom_element_id("gpui_img", ctx.id))
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(gpui::rgba(0x1f2230ff))
+            .border(gpui::px(1.0))
+            .border_color(gpui::rgba(0x5d6481ff))
+            .text_color(gpui::rgba(0xa4accdff)),
+        ctx,
+    );
+    fallback =
+        crate::accessibility::apply_accessibility(fallback, ctx.props, Some(gpui::Role::Image));
+    fallback = crate::accessibility::apply_image_label(fallback, ctx.props, alt);
+    fallback
+        .child(ctx.chrome_text(message.to_string(), None))
+        .into_any_element()
 }
 
 impl CustomElement for ImgElement {
+    // GPUI layout uses f32 pixels; style dimensions arrive as JSON f64 values.
+    #[allow(clippy::cast_possible_truncation)]
     fn render(
         &mut self,
         ctx: CustomRenderContext,
@@ -75,22 +176,18 @@ impl CustomElement for ImgElement {
     ) -> gpui::AnyElement {
         use gpui::prelude::*;
 
-        if self.src.trim().is_empty() {
-            let fallback = gpui::div().id(super::custom_element_id("__gpui_vue_img", ctx.id));
-            let fallback = super::custom_surface(fallback, &ctx)
-                .flex()
-                .items_center()
-                .justify_center()
-                .bg(gpui::rgba(0x1f2230ff))
-                .border(gpui::px(1.0))
-                .border_color(gpui::rgba(0x5d6481ff))
-                .text_color(gpui::rgba(0xa4accdff))
-                .child(ctx.chrome_text("img: no src", None));
-
-            return fallback.into_any_element();
-        }
-
-        let mut el = gpui::img(self.src.clone())
+        let el = match &self.source {
+            ImgSource::Path(path) => gpui::img(path.clone()),
+            ImgSource::Uri(uri) => gpui::img(uri.clone()),
+            ImgSource::Data(image) => gpui::img(image.clone()),
+            ImgSource::Empty => return img_fallback(&ctx, &self.alt, "img: no src"),
+            ImgSource::Invalid => return img_fallback(&ctx, &self.alt, "img: load failed"),
+        };
+        // The id is what makes gpui's `ImgState` persist. Without it `Img` has no
+        // `GlobalElementId`, so the animated-GIF frame index and the delayed
+        // loading state are rebuilt from scratch on every frame and an animation
+        // never advances past frame zero.
+        let mut el = el
             .object_fit(self.object_fit.as_gpui())
             .with_fallback(|| {
                 gpui::div()
@@ -104,31 +201,47 @@ impl CustomElement for ImgElement {
                     .child(crate::text::chrome_text("img: load failed".into(), None))
                     .into_any_element()
             })
-            .id(super::custom_element_id("__gpui_vue_img", ctx.id));
+            .id(super::custom_element_id("gpui_img", ctx.id));
 
         if let Some(style) = ctx.style {
             el = crate::renderer::apply_interactive_styles(el, style);
+            // GPUI fills `aspect_ratio` from the bitmap once it loads. That
+            // overrides a definite height and jumps the box. A CSS `<img>` with
+            // both width and height keeps that box; `objectFit` paints inside it.
+            if let (
+                Some(crate::style::DimensionValue::Pixels(width)),
+                Some(crate::style::DimensionValue::Pixels(height)),
+            ) = (style.width.as_ref(), style.height.as_ref())
+                && *width > 0.0
+                && *height > 0.0
+            {
+                el = el.aspect_ratio((*width as f32) / (*height as f32));
+            }
         }
 
+        let mut el =
+            crate::accessibility::apply_accessibility(el, ctx.props, Some(gpui::Role::Image));
+        el = crate::accessibility::apply_image_label(el, ctx.props, &self.alt);
         let el = super::wire_standard_events(el, &ctx);
         crate::automation::track_own_bounds(el, ctx.id).into_any_element()
     }
 
     fn set_prop(&mut self, key: &str, value: serde_json::Value) {
         match key {
-            "src" => self.src = value.as_str().unwrap_or("").to_string(),
+            "src" => self.load_src(value.as_str().unwrap_or("")),
             "objectFit" => {
                 self.object_fit = value
                     .as_str()
                     .map(ImgObjectFit::from_str)
                     .unwrap_or_default();
             }
+            "alt" => self.alt = value.as_str().unwrap_or_default().to_string(),
             _ => {}
         }
     }
 
     fn supported_props(&self) -> &'static [&'static str] {
-        &["src", "objectFit"]
+        &["src", "objectFit", "alt"]
     }
 
     fn supported_events(&self) -> &'static [&'static str] {
@@ -136,6 +249,44 @@ impl CustomElement for ImgElement {
     }
 
     fn destroy(&mut self) {}
+}
+
+fn decode_image_data_url(src: &str) -> Option<(gpui::ImageFormat, Vec<u8>)> {
+    let (metadata, data) = src.strip_prefix("data:")?.split_once(',')?;
+    let mut parts = metadata.split(';');
+    let mime_type = parts.next()?.to_ascii_lowercase();
+    let format = gpui::ImageFormat::from_mime_type(&mime_type)?;
+    let is_base64 = parts.any(|part| part.eq_ignore_ascii_case("base64"));
+    let bytes = if is_base64 {
+        base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .ok()?
+    } else {
+        decode_image_percent_bytes(data)
+    };
+    Some((format, bytes))
+}
+
+fn decode_image_percent_bytes(input: &str) -> Vec<u8> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let Ok(value) = u8::from_str_radix(
+                std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or(""),
+                16,
+            )
+        {
+            out.push(value);
+            index += 3;
+            continue;
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    out
 }
 
 #[derive(Debug, Clone, Default)]
@@ -273,6 +424,6 @@ mod tests {
             "src",
             serde_json::Value::String("https://example.com/image.png".to_string()),
         );
-        assert_eq!(image.src, "https://example.com/image.png");
+        assert!(matches!(image.source, ImgSource::Uri(_)));
     }
 }

--- a/crates/gpui-core/src/custom_elements/input.rs
+++ b/crates/gpui-core/src/custom_elements/input.rs
@@ -1,6 +1,12 @@
 //! Native single-line and multiline text editors with platform IME support.
 //!
-//! Caret blinking is ported from Comet's `crates/ui/src/composer.rs` (MIT).
+//! The editor follows GPUI's input example:
+//! <https://github.com/zed-industries/zed/blob/main/crates/gpui/examples/input.rs>
+//! Caret blinking, double-click, drag autoscroll, and bounded undo follow
+//! Comet's composer (MIT). Use Comet only as a generic editor behavior
+//! reference; its composer contains app-specific code.
+//! Upstream: <https://github.com/zeronsh/comet/blob/main/crates/ui/src/composer.rs>
+//! Reviewed at: <https://github.com/zeronsh/comet/blob/b3fa51872f70c8f973c241b659cf0c166766f4f5/crates/ui/src/composer.rs>
 
 #![allow(
     clippy::cast_possible_truncation,
@@ -13,7 +19,7 @@ use std::ops::Range;
 use std::time::Duration;
 
 use gpui::{
-    App, Bounds, ClipboardItem, Context, CursorStyle, ElementInputHandler, Entity,
+    App, Bounds, ClipboardItem, Context, CursorStyle, DispatchPhase, ElementInputHandler, Entity,
     EntityInputHandler, FocusHandle, GlobalElementId, KeyBinding, LayoutId, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, ScrollWheelEvent,
     SharedString, Style, Task, TextRun, TextStyle, UTF16Selection, UnderlineStyle, Window,
@@ -68,12 +74,68 @@ actions!(
 
 const INPUT_KEY_CONTEXT: &str = "GpuixInput";
 const TEXTAREA_KEY_CONTEXT: &str = "GpuixTextarea";
+const TEXTAREA_SUBMIT_KEY_CONTEXT: &str = "GpuixTextareaSubmit";
 const CARET_BLINK_MS: u64 = 500;
-const MAX_EDIT_HISTORY_ENTRIES: usize = 256;
+const CARET_WIDTH: Pixels = px(2.0);
+const CARET_HEIGHT_RATIO: f32 = 0.75;
+const DRAG_SCROLL_FRAME_MS: u64 = 16;
+const UNDO_COALESCE: Duration = Duration::from_millis(700);
+const UNDO_LIMIT: usize = 256;
 const MAX_EDIT_HISTORY_BYTES: usize = 8 * 1024 * 1024;
 
 fn caret_visible(ms_since_activity: u64) -> bool {
     (ms_since_activity / CARET_BLINK_MS).is_multiple_of(2)
+}
+
+// Size the bar to cap height, not the line box. Default leading is phi, so a
+// full-height caret sticks out above and below the glyphs. Cap height is about
+// 0.75em; the em square itself still looks taller than the letters.
+fn caret_rect(origin: Point<Pixels>, line_height: Pixels, font_size: Pixels) -> Bounds<Pixels> {
+    let height = (font_size * CARET_HEIGHT_RATIO).min(line_height);
+    let y_offset = (line_height - height) / 2.;
+    Bounds::new(
+        point(origin.x, origin.y + y_offset),
+        size(CARET_WIDTH, height),
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PressIntent {
+    SelectAll,
+    SelectWord,
+    ExtendSelection,
+    PlaceCaret,
+}
+
+impl PressIntent {
+    fn arms_drag(self) -> bool {
+        matches!(self, Self::ExtendSelection | Self::PlaceCaret)
+    }
+}
+
+fn press_intent(click_count: usize, shift: bool) -> PressIntent {
+    match click_count {
+        n if n >= 3 => PressIntent::SelectAll,
+        2 => PressIntent::SelectWord,
+        _ if shift => PressIntent::ExtendSelection,
+        _ => PressIntent::PlaceCaret,
+    }
+}
+
+fn drag_scroll_delta(
+    pointer_y: f32,
+    viewport_top: f32,
+    viewport_bottom: f32,
+    line_height: f32,
+) -> f32 {
+    let distance = if pointer_y < viewport_top {
+        pointer_y - viewport_top
+    } else if pointer_y > viewport_bottom {
+        pointer_y - viewport_bottom
+    } else {
+        return 0.0;
+    };
+    distance.signum() * (distance.abs() * 0.2).clamp(1.0, line_height)
 }
 
 fn utf16_offset_to_utf8(text: &str, offset: usize) -> usize {
@@ -93,42 +155,26 @@ fn single_line_text(text: &str) -> String {
     text.replace("\r\n", " ").replace(['\r', '\n'], " ")
 }
 
-fn remap_offset_after_external_edit(old: &str, new: &str, offset: usize) -> usize {
-    let prefix = old
-        .chars()
-        .zip(new.chars())
-        .take_while(|(old, new)| old == new)
-        .map(|(character, _)| character.len_utf8())
-        .sum::<usize>();
-    let suffix = old[prefix..]
-        .chars()
-        .rev()
-        .zip(new[prefix..].chars().rev())
-        .take_while(|(old, new)| old == new)
-        .map(|(character, _)| character.len_utf8())
-        .sum::<usize>();
-    let old_changed_end = old.len().saturating_sub(suffix);
-    let new_changed_end = new.len().saturating_sub(suffix);
-    match offset.min(old.len()) {
-        offset if offset <= prefix => offset,
-        offset if offset >= old_changed_end => {
-            new_changed_end + offset.saturating_sub(old_changed_end)
-        }
-        _ => new_changed_end,
-    }
-}
-
 pub fn init(cx: &mut App) {
     let word_navigation_uses_alt = word_navigation_uses_alt();
     let bind_paste_shortcut = !cfg!(all(target_arch = "wasm32", target_os = "unknown"));
     let mut bindings = text_editor_bindings(
         INPUT_KEY_CONTEXT,
         false,
+        true,
         word_navigation_uses_alt,
         bind_paste_shortcut,
     );
     bindings.extend(text_editor_bindings(
         TEXTAREA_KEY_CONTEXT,
+        true,
+        false,
+        word_navigation_uses_alt,
+        bind_paste_shortcut,
+    ));
+    bindings.extend(text_editor_bindings(
+        TEXTAREA_SUBMIT_KEY_CONTEXT,
+        true,
         true,
         word_navigation_uses_alt,
         bind_paste_shortcut,
@@ -136,15 +182,22 @@ pub fn init(cx: &mut App) {
     cx.bind_keys(bindings);
 }
 
+// These flags are independent platform and editor capabilities.
+#[allow(clippy::fn_params_excessive_bools)]
 fn text_editor_bindings(
     context: &'static str,
     multiline: bool,
+    enter_submits: bool,
     word_navigation_uses_alt: bool,
     bind_paste_shortcut: bool,
 ) -> Vec<KeyBinding> {
     let context = Some(context);
     let mut bindings = vec![
-        KeyBinding::new("enter", Submit, context),
+        if enter_submits {
+            KeyBinding::new("enter", Submit, context)
+        } else {
+            KeyBinding::new("enter", Newline, context)
+        },
         KeyBinding::new("shift-enter", Newline, context),
         KeyBinding::new("backspace", Backspace, context),
         KeyBinding::new("delete", Delete, context),
@@ -212,7 +265,7 @@ fn text_editor_bindings(
     bindings
 }
 
-#[cfg(any(test, all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(any(test, target_family = "wasm"))]
 fn browser_platform_is_macos(platform: &str, user_agent: &str) -> bool {
     platform.starts_with("Mac")
         || user_agent.contains("Macintosh")
@@ -318,9 +371,6 @@ impl CustomElement for TextEditorElement {
                 let min_rows = self.min_rows;
                 let max_rows = self.max_rows;
                 let caret_color = self.theme.caret;
-                let placeholder_color = self.theme.text_faint;
-                let mut selection_color = self.theme.accent;
-                selection_color.a = 0.35;
                 let callback = callback.clone();
                 let id = ctx.id;
                 let cursor = value.len();
@@ -343,27 +393,27 @@ impl CustomElement for TextEditorElement {
                     selection_reversed: false,
                     marked_range: None,
                     is_selecting: false,
+                    drag_position: None,
+                    drag_generation: 0,
+                    drag_autoscroll_active: false,
                     scroll_top: 0.0,
                     scroll_left: 0.0,
                     follow_cursor: true,
                     last_lines: Vec::new(),
                     line_starts: vec![0],
-                    line_y_offsets: vec![px(0.0)],
                     last_bounds: None,
                     line_height: px(20.0),
+                    font_size: px(16.0),
                     content_height: 20.0,
                     content_width: 0.0,
                     display_is_placeholder: false,
                     caret_color,
-                    placeholder_color,
-                    selection_color,
                     blink_anchor: cx.background_executor().now(),
                     blink_task: None,
                     pending_values: VecDeque::new(),
                     undo_stack: VecDeque::new(),
                     redo_stack: VecDeque::new(),
-                    undo_bytes: 0,
-                    redo_bytes: 0,
+                    last_edit: None,
                 })
             })
             .clone();
@@ -372,7 +422,10 @@ impl CustomElement for TextEditorElement {
         state.update(cx, |state, cx| {
             state.callback = callback;
             state.emits_change = emits_change;
-            state.emits_submit = emits_submit;
+            if state.emits_submit != emits_submit {
+                state.emits_submit = emits_submit;
+                cx.notify();
+            }
             state.emits_key_down = emits_key_down;
             state.emits_key_up = emits_key_up;
             state.placeholder = self.placeholder.clone().into();
@@ -383,16 +436,13 @@ impl CustomElement for TextEditorElement {
                 state.caret_color = self.theme.caret;
                 cx.notify();
             }
-            state.placeholder_color = self.theme.text_faint;
-            state.selection_color = self.theme.accent;
-            state.selection_color.a = 0.35;
             if prop_changed {
                 state.sync_prop_value(self.value.clone(), cx);
             }
         });
         self.last_prop_value = Some(self.value.clone());
 
-        let element_id = super::custom_element_id("__gpui_vue_editor", ctx.id);
+        let element_id = super::custom_element_id("gpui_editor", ctx.id);
         let mut editor = div()
             .id(element_id)
             .flex()
@@ -400,8 +450,16 @@ impl CustomElement for TextEditorElement {
             .w_full()
             .track_focus(&focus_handle)
             .child(state);
+        // Single-line inputs center text vertically when given extra height.
+        if !self.multiline {
+            editor = editor.items_center();
+        }
         if let Some(style) = ctx.style {
             editor = crate::renderer::apply_interactive_styles(editor, style);
+            // Clip text to rounded corners, matching HTML input behavior.
+            if style.border_radius.is_some() {
+                editor = editor.overflow_hidden();
+            }
         }
         if ctx
             .style
@@ -409,6 +467,18 @@ impl CustomElement for TextEditorElement {
             .is_none()
         {
             editor = editor.relative();
+        }
+        let default_role = if self.multiline {
+            gpui::Role::MultilineTextInput
+        } else {
+            gpui::Role::TextInput
+        };
+        editor = crate::accessibility::apply_accessibility(editor, ctx.props, Some(default_role));
+        if ctx.props.get("aria-valuetext").is_none() && !self.value.is_empty() {
+            editor = editor.aria_value(self.value.clone());
+        }
+        if !self.placeholder.is_empty() {
+            editor = editor.aria_placeholder(self.placeholder.clone());
         }
         // Custom elements paint themselves, so nothing registers their box for
         // automation unless the builder does it. Without this, a locator on an
@@ -422,15 +492,26 @@ impl CustomElement for TextEditorElement {
         if ctx.events.contains("click") {
             let callback = ctx.event_callback.clone();
             let id = ctx.id;
-            editor = editor.on_click(move |event, _window, _cx| {
+            // Match retained hosts: GPUI's semantic click is unreliable under
+            // embedded AppKit pumping, so primary mouse-up is the click boundary.
+            editor = editor.on_mouse_up(MouseButton::Left, move |event, _window, _cx| {
                 emit_event_full(&callback, id, "click", |payload| {
-                    let (x, y) = crate::renderer::point_to_xy(event.position());
+                    let (x, y) = crate::renderer::point_to_xy(event.position);
                     payload.x = Some(x);
                     payload.y = Some(y);
-                    payload.modifiers = Some(event.modifiers().into());
+                    payload.button = Some(0);
+                    payload.click_count = Some(event.click_count as u32);
+                    payload.modifiers = Some(event.modifiers.into());
+                    payload.is_right_click = Some(false);
                 });
             });
         }
+        editor = crate::accessibility::apply_a11y_click(
+            editor,
+            ctx.events,
+            ctx.id,
+            ctx.event_callback.as_ref(),
+        );
         editor.into_any_element()
     }
 
@@ -480,10 +561,89 @@ struct EditSnapshot {
     selection_reversed: bool,
 }
 
-#[allow(
-    clippy::struct_excessive_bools,
-    reason = "independent editor capabilities and event subscriptions are explicit state flags"
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditKind {
+    Insert,
+    DeleteBackward,
+    DeleteForward,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CoalescingEdit {
+    kind: EditKind,
+    anchor: usize,
+}
+
+#[derive(Clone, Copy)]
+struct LastEdit {
+    edit: CoalescingEdit,
+    when: Instant,
+}
+
+fn coalescing_edit(
+    range: &Range<usize>,
+    new_text: &str,
+    selection_reversed: bool,
+) -> Option<CoalescingEdit> {
+    if new_text.is_empty() {
+        if range.is_empty() {
+            return None;
+        }
+        return Some(CoalescingEdit {
+            kind: if selection_reversed {
+                EditKind::DeleteBackward
+            } else {
+                EditKind::DeleteForward
+            },
+            anchor: range.start,
+        });
+    }
+
+    let mut characters = new_text.chars();
+    let character = characters.next()?;
+    (range.is_empty() && characters.next().is_none() && !character.is_whitespace()).then_some(
+        CoalescingEdit {
+            kind: EditKind::Insert,
+            anchor: range.start + new_text.len(),
+        },
+    )
+}
+
+fn edits_coalesce(
+    previous: CoalescingEdit,
+    current: Option<CoalescingEdit>,
+    range: &Range<usize>,
+    elapsed: Duration,
+) -> bool {
+    let Some(current) = current else {
+        return false;
+    };
+    if previous.kind != current.kind || elapsed >= UNDO_COALESCE {
+        return false;
+    }
+    match current.kind {
+        EditKind::Insert | EditKind::DeleteForward => range.start == previous.anchor,
+        EditKind::DeleteBackward => range.end == previous.anchor,
+    }
+}
+
+fn push_undo_snapshot(history: &mut VecDeque<EditSnapshot>, snapshot: EditSnapshot) {
+    let mut bytes = history
+        .iter()
+        .map(|entry| entry.content.len())
+        .sum::<usize>()
+        + snapshot.content.len();
+    history.push_back(snapshot);
+    while history.len() > UNDO_LIMIT || bytes > MAX_EDIT_HISTORY_BYTES {
+        let Some(removed) = history.pop_front() else {
+            break;
+        };
+        bytes = bytes.saturating_sub(removed.content.len());
+    }
+}
+
+// Event subscriptions and editing modes are independent flags.
+#[allow(clippy::struct_excessive_bools)]
 struct TextEditorState {
     element_id: u64,
     callback: Option<EventCallback>,
@@ -502,27 +662,27 @@ struct TextEditorState {
     selection_reversed: bool,
     marked_range: Option<Range<usize>>,
     is_selecting: bool,
+    drag_position: Option<Point<Pixels>>,
+    drag_generation: u64,
+    drag_autoscroll_active: bool,
     scroll_top: f32,
     scroll_left: f32,
     follow_cursor: bool,
     last_lines: Vec<WrappedLine>,
     line_starts: Vec<usize>,
-    line_y_offsets: Vec<Pixels>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
+    font_size: Pixels,
     content_height: f32,
     content_width: f32,
     display_is_placeholder: bool,
     caret_color: gpui::Hsla,
-    placeholder_color: gpui::Hsla,
-    selection_color: gpui::Hsla,
     blink_anchor: Instant,
     blink_task: Option<Task<()>>,
     pending_values: VecDeque<String>,
     undo_stack: VecDeque<EditSnapshot>,
     redo_stack: VecDeque<EditSnapshot>,
-    undo_bytes: usize,
-    redo_bytes: usize,
+    last_edit: Option<LastEdit>,
 }
 
 impl TextEditorState {
@@ -559,43 +719,6 @@ impl TextEditorState {
         }
     }
 
-    fn push_history(
-        stack: &mut VecDeque<EditSnapshot>,
-        retained_bytes: &mut usize,
-        snapshot: EditSnapshot,
-    ) {
-        *retained_bytes = retained_bytes.saturating_add(snapshot.content.len());
-        stack.push_back(snapshot);
-        while stack.len() > MAX_EDIT_HISTORY_ENTRIES || *retained_bytes > MAX_EDIT_HISTORY_BYTES {
-            let Some(discarded) = stack.pop_front() else {
-                break;
-            };
-            *retained_bytes = retained_bytes.saturating_sub(discarded.content.len());
-        }
-    }
-
-    fn pop_history(
-        stack: &mut VecDeque<EditSnapshot>,
-        retained_bytes: &mut usize,
-    ) -> Option<EditSnapshot> {
-        let snapshot = stack.pop_back()?;
-        *retained_bytes = retained_bytes.saturating_sub(snapshot.content.len());
-        Some(snapshot)
-    }
-
-    fn clear_redo_history(&mut self) {
-        self.redo_stack.clear();
-        self.redo_bytes = 0;
-    }
-
-    fn push_undo(&mut self, snapshot: EditSnapshot) {
-        Self::push_history(&mut self.undo_stack, &mut self.undo_bytes, snapshot);
-    }
-
-    fn push_redo(&mut self, snapshot: EditSnapshot) {
-        Self::push_history(&mut self.redo_stack, &mut self.redo_bytes, snapshot);
-    }
-
     fn sync_prop_value(&mut self, value: String, cx: &mut Context<Self>) {
         if let Some(index) = self
             .pending_values
@@ -613,17 +736,18 @@ impl TextEditorState {
         if self.content == value {
             return;
         }
-        let old_content = std::mem::replace(&mut self.content, value);
-        let map_offset =
-            |offset| remap_offset_after_external_edit(&old_content, &self.content, offset);
-        self.selected_range =
-            map_offset(self.selected_range.start)..map_offset(self.selected_range.end);
-        self.marked_range = self
-            .marked_range
-            .as_ref()
-            .map(|range| map_offset(range.start)..map_offset(range.end));
+        self.content = value;
+        let end = self.content.len();
+        self.selected_range = end..end;
+        self.selection_reversed = false;
+        self.marked_range = None;
+        self.scroll_top = 0.0;
+        self.scroll_left = 0.0;
         self.follow_cursor = true;
         self.reset_blink(cx);
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.last_edit = None;
         cx.notify();
     }
 
@@ -653,9 +777,28 @@ impl TextEditorState {
         self.selection_reversed = snapshot.selection_reversed;
         self.marked_range = None;
         self.follow_cursor = true;
+        self.last_edit = None;
         self.reset_blink(cx);
         self.emit_change();
         cx.notify();
+    }
+
+    fn record_edit(&mut self, range: &Range<usize>, new_text: &str, now: Instant) {
+        let current = coalescing_edit(range, new_text, self.selection_reversed);
+        let mergeable = self.last_edit.is_some_and(|previous| {
+            edits_coalesce(
+                previous.edit,
+                current,
+                range,
+                now.duration_since(previous.when),
+            )
+        });
+        if !mergeable {
+            let snapshot = self.snapshot();
+            push_undo_snapshot(&mut self.undo_stack, snapshot);
+        }
+        self.redo_stack.clear();
+        self.last_edit = current.map(|edit| LastEdit { edit, when: now });
     }
 
     fn cursor_offset(&self) -> usize {
@@ -975,9 +1118,9 @@ impl TextEditorState {
         if self.read_only {
             return;
         }
-        if let Some(previous) = Self::pop_history(&mut self.undo_stack, &mut self.undo_bytes) {
-            let current = self.snapshot();
-            self.push_redo(current);
+        if let Some(previous) = self.undo_stack.pop_back() {
+            let snapshot = self.snapshot();
+            push_undo_snapshot(&mut self.redo_stack, snapshot);
             self.restore(previous, cx);
         }
     }
@@ -986,9 +1129,9 @@ impl TextEditorState {
         if self.read_only {
             return;
         }
-        if let Some(next) = Self::pop_history(&mut self.redo_stack, &mut self.redo_bytes) {
-            let current = self.snapshot();
-            self.push_undo(current);
+        if let Some(next) = self.redo_stack.pop_back() {
+            let snapshot = self.snapshot();
+            push_undo_snapshot(&mut self.undo_stack, snapshot);
             self.restore(next, cx);
         }
     }
@@ -1016,48 +1159,41 @@ impl TextEditorState {
     }
 
     fn point_for_index(&self, index: usize) -> Option<Point<Pixels>> {
-        let line_index = self
-            .line_starts
-            .partition_point(|line_start| *line_start <= index)
-            .saturating_sub(1)
-            .min(self.last_lines.len().saturating_sub(1));
-        let line = self.last_lines.get(line_index)?;
-        let line_start = *self.line_starts.get(line_index)?;
-        let local = line.position_for_index(
-            index.saturating_sub(line_start).min(line.len()),
-            self.line_height,
-        )?;
-        Some(point(
-            local.x,
-            local.y + self.line_y_offsets.get(line_index).copied()?,
-        ))
+        for (line_index, line) in self.last_lines.iter().enumerate() {
+            let line_start = *self.line_starts.get(line_index)?;
+            if index < line_start || index > line_start + line.len() {
+                continue;
+            }
+            let local = line.position_for_index(index - line_start, self.line_height)?;
+            let y_offset: Pixels = self
+                .last_lines
+                .iter()
+                .take(line_index)
+                .map(|line| line.size(self.line_height).height)
+                .sum();
+            return Some(point(local.x, local.y + y_offset));
+        }
+        None
     }
 
     fn index_for_point(&self, position: Point<Pixels>) -> usize {
         if self.display_is_placeholder {
             return 0;
         }
-        let y = f32::from(position.y).max(0.0);
-        let line_index = self
-            .line_y_offsets
-            .partition_point(|offset| f32::from(*offset) <= y)
-            .saturating_sub(1)
-            .min(self.last_lines.len().saturating_sub(1));
-        let Some(line) = self.last_lines.get(line_index) else {
-            return self.content.len();
-        };
-        let line_top = self
-            .line_y_offsets
-            .get(line_index)
-            .copied()
-            .map(f32::from)
-            .unwrap_or_default();
-        let height = f32::from(line.size(self.line_height).height);
-        let local = point(position.x, px((y - line_top).min(height - 1.0).max(0.0)));
-        let index = line
-            .closest_index_for_position(local, self.line_height)
-            .unwrap_or_else(|index| index);
-        (self.line_starts.get(line_index).copied().unwrap_or(0) + index).min(self.content.len())
+        let mut y = f32::from(position.y).max(0.0);
+        for (line_index, line) in self.last_lines.iter().enumerate() {
+            let height = f32::from(line.size(self.line_height).height);
+            let line_start = self.line_starts.get(line_index).copied().unwrap_or(0);
+            if y < height || line_index + 1 == self.last_lines.len() {
+                let local = point(position.x, px(y.min(height - 1.0).max(0.0)));
+                let index = line
+                    .closest_index_for_position(local, self.line_height)
+                    .unwrap_or_else(|index| index);
+                return (line_start + index).min(self.content.len());
+            }
+            y -= height;
+        }
+        self.content.len()
     }
 
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
@@ -1080,25 +1216,124 @@ impl TextEditorState {
             window.request_text_input();
         }
         window.focus(&self.focus_handle, cx);
-        self.is_selecting = true;
-        let index = self.index_for_mouse_position(event.position);
-        if event.modifiers.shift {
-            self.select_to(index, cx);
-        } else {
-            self.move_to(index, cx);
+        let intent = press_intent(event.click_count, event.modifiers.shift);
+        self.is_selecting = intent.arms_drag();
+        self.drag_position = intent.arms_drag().then_some(event.position);
+        self.drag_generation = self.drag_generation.wrapping_add(1);
+        self.drag_autoscroll_active = false;
+        match intent {
+            PressIntent::SelectAll => {
+                self.move_to(0, cx);
+                self.select_to(self.content.len(), cx);
+            }
+            PressIntent::SelectWord => {
+                let index = self.index_for_mouse_position(event.position);
+                let range = crate::text::selection::word_range(&self.content, index);
+                self.move_to(range.start, cx);
+                self.select_to(range.end, cx);
+            }
+            PressIntent::ExtendSelection => {
+                self.select_to(self.index_for_mouse_position(event.position), cx);
+            }
+            PressIntent::PlaceCaret => {
+                self.move_to(self.index_for_mouse_position(event.position), cx);
+            }
         }
     }
 
     fn on_mouse_up(&mut self, _: &MouseUpEvent, _: &mut Window, _: &mut Context<Self>) {
         self.is_selecting = false;
+        self.drag_position = None;
+        self.drag_generation = self.drag_generation.wrapping_add(1);
+        self.drag_autoscroll_active = false;
     }
 
-    fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
+    fn on_mouse_move(&mut self, event: &MouseMoveEvent, cx: &mut Context<Self>) {
         if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+            self.drag_position = Some(event.position);
+            let position = self.drag_selection_position(event.position);
+            self.select_to(self.index_for_mouse_position(position), cx);
+            if self.multiline
+                && self.drag_scroll_delta(event.position) != 0.0
+                && !self.drag_autoscroll_active
+            {
+                self.start_drag_autoscroll(cx);
+            }
         }
     }
 
+    fn start_drag_autoscroll(&mut self, cx: &mut Context<Self>) {
+        self.drag_autoscroll_active = true;
+        let generation = self.drag_generation;
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(DRAG_SCROLL_FRAME_MS))
+                    .await;
+                let keep_running = this
+                    .update(cx, |input, cx| input.drag_autoscroll_tick(generation, cx))
+                    .unwrap_or(false);
+                if !keep_running {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn drag_selection_position(&self, position: Point<Pixels>) -> Point<Pixels> {
+        let Some(bounds) = self.last_bounds else {
+            return position;
+        };
+        let x = if self.multiline {
+            position.x.clamp(bounds.left(), bounds.right() - px(0.5))
+        } else {
+            position.x
+        };
+        point(x, position.y.clamp(bounds.top(), bounds.bottom() - px(0.5)))
+    }
+
+    fn drag_scroll_delta(&self, position: Point<Pixels>) -> f32 {
+        let Some(bounds) = self.last_bounds else {
+            return 0.0;
+        };
+        drag_scroll_delta(
+            f32::from(position.y),
+            f32::from(bounds.top()),
+            f32::from(bounds.bottom()),
+            f32::from(self.line_height),
+        )
+    }
+
+    // Exact equality detects a clamped scroll boundary without dropping subpixel moves.
+    #[allow(clippy::float_cmp)]
+    fn drag_autoscroll_tick(&mut self, generation: u64, cx: &mut Context<Self>) -> bool {
+        if !self.multiline || !self.is_selecting || self.drag_generation != generation {
+            return false;
+        }
+        let (Some(position), Some(bounds)) = (self.drag_position, self.last_bounds) else {
+            self.drag_autoscroll_active = false;
+            return false;
+        };
+        let delta = self.drag_scroll_delta(position);
+        if delta == 0.0 {
+            self.drag_autoscroll_active = false;
+            return false;
+        }
+        let max_scroll = (self.content_height - f32::from(bounds.size.height)).max(0.0);
+        let next = (self.scroll_top + delta).clamp(0.0, max_scroll);
+        if next == self.scroll_top {
+            self.drag_autoscroll_active = false;
+            return false;
+        }
+        self.scroll_top = next;
+        let edge_position = self.drag_selection_position(position);
+        self.select_to(self.index_for_mouse_position(edge_position), cx);
+        self.follow_cursor = false;
+        true
+    }
+
+    #[allow(clippy::float_cmp)]
     fn on_scroll_wheel(
         &mut self,
         event: &ScrollWheelEvent,
@@ -1114,7 +1349,14 @@ impl TextEditorState {
             return;
         }
         let delta = f32::from(event.delta.pixel_delta(self.line_height).y);
-        self.scroll_top = (self.scroll_top - delta).clamp(0.0, max_scroll);
+        let next = (self.scroll_top - delta).clamp(0.0, max_scroll);
+        if next == self.scroll_top {
+            if delta != 0.0 {
+                cx.stop_propagation();
+            }
+            return;
+        }
+        self.scroll_top = next;
         self.follow_cursor = false;
         cx.stop_propagation();
         cx.notify();
@@ -1154,9 +1396,6 @@ impl TextEditorState {
         self.offset_from_utf16(range.start)..self.offset_from_utf16(range.end)
     }
 
-    // Clippy's method-reference rewrite names SmallVec's transitive crate, which is
-    // intentionally not part of this crate's public dependency surface.
-    #[allow(clippy::redundant_closure_for_method_calls)]
     fn layout_text(&mut self, width: Pixels, style: &TextStyle, window: &mut Window) -> f32 {
         let (display, is_placeholder) = if self.content.is_empty() {
             (self.placeholder.clone(), true)
@@ -1164,9 +1403,10 @@ impl TextEditorState {
             (SharedString::from(self.content.clone()), false)
         };
         let font_size = style.font_size.to_pixels(window.rem_size());
+        self.font_size = font_size;
         self.line_height = window.line_height();
         let color = if is_placeholder {
-            self.placeholder_color
+            gpui::rgba(0x8f8f8fff).into()
         } else {
             style.color
         };
@@ -1194,26 +1434,25 @@ impl TextEditorState {
             _ => vec![run(display.len(), false)],
         };
         let wrap_width = self.multiline.then_some(width);
-        let lines = window
+        let lines: Vec<_> = window
             .text_system()
             .shape_text(display, font_size, &runs, wrap_width, None)
-            .map(|lines| lines.into_vec())
+            .map(|ranges| ranges.into_iter().collect())
             .unwrap_or_default();
         let mut line_starts = Vec::with_capacity(lines.len());
-        let mut line_y_offsets = Vec::with_capacity(lines.len());
         let mut offset = 0;
-        let mut y_offset = 0.0;
         for line in &lines {
             line_starts.push(offset);
-            line_y_offsets.push(px(y_offset));
             offset += line.len() + 1;
-            y_offset += f32::from(line.size(self.line_height).height);
         }
         if line_starts.is_empty() {
             line_starts.push(0);
-            line_y_offsets.push(px(0.0));
         }
-        self.content_height = y_offset.max(f32::from(self.line_height));
+        self.content_height = lines
+            .iter()
+            .map(|line| f32::from(line.size(self.line_height).height))
+            .sum::<f32>()
+            .max(f32::from(self.line_height));
         self.content_width = lines
             .iter()
             .map(|line| f32::from(line.unwrapped_layout.width))
@@ -1221,7 +1460,6 @@ impl TextEditorState {
         self.display_is_placeholder = is_placeholder;
         self.last_lines = lines;
         self.line_starts = line_starts;
-        self.line_y_offsets = line_y_offsets;
         self.content_height
     }
 
@@ -1307,16 +1545,14 @@ impl EntityInputHandler for TextEditorState {
             .map(|range| self.range_from_utf16(range))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
-        if self.marked_range.is_none() {
-            let snapshot = self.snapshot();
-            self.push_undo(snapshot);
-            self.clear_redo_history();
-        }
         let replacement = if self.multiline {
             new_text.to_string()
         } else {
             single_line_text(new_text)
         };
+        if self.marked_range.is_none() {
+            self.record_edit(&range, &replacement, cx.background_executor().now());
+        }
         self.content =
             self.content[..range.start].to_owned() + &replacement + &self.content[range.end..];
         let cursor = range.start + replacement.len();
@@ -1347,8 +1583,9 @@ impl EntityInputHandler for TextEditorState {
             .unwrap_or(self.selected_range.clone());
         if self.marked_range.is_none() {
             let snapshot = self.snapshot();
-            self.push_undo(snapshot);
-            self.clear_redo_history();
+            push_undo_snapshot(&mut self.undo_stack, snapshot);
+            self.redo_stack.clear();
+            self.last_edit = None;
         }
         let replacement = if self.multiline {
             new_text.to_string()
@@ -1381,12 +1618,13 @@ impl EntityInputHandler for TextEditorState {
     ) -> Option<Bounds<Pixels>> {
         let range = self.range_from_utf16(&range_utf16);
         let start = self.point_for_index(range.start)?;
-        Some(Bounds::new(
+        Some(caret_rect(
             point(
                 bounds.left() + start.x - px(self.scroll_left),
                 bounds.top() + start.y - px(self.scroll_top),
             ),
-            size(px(2.0), self.line_height),
+            self.line_height,
+            self.font_size,
         ))
     }
 
@@ -1427,10 +1665,12 @@ impl gpui::Render for TextEditorState {
         let key_up_callback = self.callback.clone();
         let element_id = self.element_id;
         div()
-            .key_context(if self.multiline {
-                TEXTAREA_KEY_CONTEXT
-            } else {
+            .key_context(if !self.multiline {
                 INPUT_KEY_CONTEXT
+            } else if self.emits_submit {
+                TEXTAREA_SUBMIT_KEY_CONTEXT
+            } else {
+                TEXTAREA_KEY_CONTEXT
             })
             .track_focus(&self.focus_handle)
             .cursor(CursorStyle::IBeam)
@@ -1471,7 +1711,6 @@ impl gpui::Render for TextEditorState {
             .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))
-            .on_mouse_move(cx.listener(Self::on_mouse_move))
             .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
             .when(self.emits_key_down, move |editor| {
                 editor.on_key_down(move |event, _window, _cx| {
@@ -1579,9 +1818,10 @@ impl gpui::Element for EditorTextElement {
                 .point_for_index(input.cursor_offset())
                 .unwrap_or(point(px(0.0), px(0.0)));
             caret = Some(fill(
-                Bounds::new(
+                caret_rect(
                     point(origin.x + caret_point.x, origin.y + caret_point.y),
-                    size(px(2.0), input.line_height),
+                    input.line_height,
+                    input.font_size,
                 ),
                 input.caret_color,
             ));
@@ -1589,7 +1829,7 @@ impl gpui::Element for EditorTextElement {
             input.point_for_index(input.selected_range.start),
             input.point_for_index(input.selected_range.end),
         ) {
-            let color = input.selection_color;
+            let color = gpui::rgba(0x7c86ff59);
             if start.y == end.y {
                 selection.push(fill(
                     Bounds::from_corners(
@@ -1643,6 +1883,12 @@ impl gpui::Element for EditorTextElement {
             ElementInputHandler::new(bounds, self.input.clone()),
             cx,
         );
+        let input = self.input.clone();
+        window.on_mouse_event(move |event: &MouseMoveEvent, phase, _, cx| {
+            if phase == DispatchPhase::Bubble && event.pressed_button == Some(MouseButton::Left) {
+                input.update(cx, |input, cx| input.on_mouse_move(event, cx));
+            }
+        });
         window.with_content_mask(Some(gpui::ContentMask { bounds }), |window| {
             for quad in prepaint.selection.drain(..) {
                 window.paint_quad(quad);
@@ -1710,7 +1956,7 @@ mod tests {
 
     #[test]
     fn macos_word_navigation_uses_alt() {
-        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true);
+        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true, true);
 
         assert!(has_binding(&bindings, "alt-left", &WordLeft));
         assert!(has_binding(&bindings, "alt-right", &WordRight));
@@ -1720,7 +1966,7 @@ mod tests {
 
     #[test]
     fn non_macos_word_navigation_uses_control() {
-        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, false, true);
+        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, false, true);
 
         assert!(has_binding(&bindings, "ctrl-left", &WordLeft));
         assert!(has_binding(&bindings, "ctrl-right", &WordRight));
@@ -1730,7 +1976,7 @@ mod tests {
 
     #[test]
     fn browser_paste_stays_with_the_dom_event() {
-        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, false);
+        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true, false);
 
         assert!(!has_binding(&bindings, "cmd-v", &Paste));
         assert!(!has_binding(&bindings, "ctrl-v", &Paste));
@@ -1738,10 +1984,27 @@ mod tests {
 
     #[test]
     fn desktop_paste_uses_the_platform_clipboard_action() {
-        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true);
+        let bindings = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true, true);
 
         assert!(has_binding(&bindings, "cmd-v", &Paste));
         assert!(has_binding(&bindings, "ctrl-v", &Paste));
+    }
+
+    #[test]
+    fn textarea_enter_inserts_a_newline_unless_on_submit_is_set() {
+        let textarea = text_editor_bindings(TEXTAREA_KEY_CONTEXT, true, false, true, true);
+        assert!(has_binding(&textarea, "enter", &Newline));
+        assert!(has_binding(&textarea, "shift-enter", &Newline));
+        assert!(!has_binding(&textarea, "enter", &Submit));
+
+        let composer = text_editor_bindings(TEXTAREA_SUBMIT_KEY_CONTEXT, true, true, true, true);
+        assert!(has_binding(&composer, "enter", &Submit));
+        assert!(has_binding(&composer, "shift-enter", &Newline));
+        assert!(!has_binding(&composer, "enter", &Newline));
+
+        let input = text_editor_bindings(INPUT_KEY_CONTEXT, false, true, true, true);
+        assert!(has_binding(&input, "enter", &Submit));
+        assert!(!has_binding(&input, "enter", &Newline));
     }
 
     #[test]
@@ -1783,9 +2046,184 @@ mod tests {
     }
 
     #[test]
+    fn caret_matches_the_font_size_inside_the_line() {
+        let bounds = caret_rect(point(px(10.0), px(4.0)), px(20.0), px(16.0));
+        assert_eq!(bounds.origin, point(px(10.0), px(8.0)));
+        assert_eq!(bounds.size, size(px(2.0), px(12.0)));
+        assert_eq!(
+            caret_rect(point(px(0.0), px(0.0)), px(20.0), px(40.0))
+                .size
+                .height,
+            px(20.0)
+        );
+    }
+
+    #[test]
     fn caret_color_comes_from_the_input_theme() {
         let mut input = TextEditorElement::new(false);
         input.set_prop("theme", serde_json::json!({ "caret": "#22c55e" }));
         assert_eq!(input.theme.caret, gpui::rgba(0x22c55eff).into());
+    }
+
+    #[test]
+    fn insertion_undo_coalescing_requires_one_contiguous_non_whitespace_character() {
+        let insert_at_one = CoalescingEdit {
+            kind: EditKind::Insert,
+            anchor: 1,
+        };
+
+        assert_eq!(coalescing_edit(&(0..0), "a", false), Some(insert_at_one));
+        assert!(edits_coalesce(
+            insert_at_one,
+            coalescing_edit(&(1..1), "b", false),
+            &(1..1),
+            Duration::from_millis(699),
+        ));
+        assert!(!edits_coalesce(
+            insert_at_one,
+            coalescing_edit(&(2..2), "b", false),
+            &(2..2),
+            Duration::from_millis(699),
+        ));
+        assert_eq!(coalescing_edit(&(0..1), "a", false), None);
+        assert_eq!(coalescing_edit(&(1..1), "ab", false), None);
+        assert_eq!(coalescing_edit(&(1..1), " ", false), None);
+        assert_eq!(coalescing_edit(&(1..1), "\n", false), None);
+        assert_eq!(coalescing_edit(&(1..1), "\t", false), None);
+        assert_eq!(coalescing_edit(&(1..1), "\u{2003}", false), None);
+        assert!(!edits_coalesce(
+            insert_at_one,
+            coalescing_edit(&(1..1), "b", false),
+            &(1..1),
+            UNDO_COALESCE,
+        ));
+        assert!(!edits_coalesce(
+            CoalescingEdit {
+                kind: EditKind::DeleteBackward,
+                anchor: 1,
+            },
+            coalescing_edit(&(1..1), "b", false),
+            &(1..1),
+            Duration::from_millis(1),
+        ));
+        assert!(!edits_coalesce(
+            insert_at_one,
+            None,
+            &(1..1),
+            Duration::from_millis(1),
+        ));
+    }
+
+    #[test]
+    fn backward_and_forward_deletions_use_their_own_contiguity_rules() {
+        let backward = CoalescingEdit {
+            kind: EditKind::DeleteBackward,
+            anchor: 3,
+        };
+        assert_eq!(
+            coalescing_edit(&(2..3), "", true),
+            Some(CoalescingEdit {
+                kind: EditKind::DeleteBackward,
+                anchor: 2,
+            })
+        );
+        assert!(edits_coalesce(
+            backward,
+            coalescing_edit(&(2..3), "", true),
+            &(2..3),
+            Duration::from_millis(699),
+        ));
+        assert!(!edits_coalesce(
+            backward,
+            coalescing_edit(&(1..2), "", true),
+            &(1..2),
+            Duration::from_millis(699),
+        ));
+
+        let forward = CoalescingEdit {
+            kind: EditKind::DeleteForward,
+            anchor: 2,
+        };
+        assert_eq!(coalescing_edit(&(2..3), "", false), Some(forward));
+        assert!(edits_coalesce(
+            forward,
+            coalescing_edit(&(2..3), "", false),
+            &(2..3),
+            Duration::from_millis(699),
+        ));
+        assert!(!edits_coalesce(
+            forward,
+            coalescing_edit(&(3..4), "", false),
+            &(3..4),
+            Duration::from_millis(699),
+        ));
+        assert!(!edits_coalesce(
+            forward,
+            coalescing_edit(&(2..3), "", false),
+            &(2..3),
+            UNDO_COALESCE,
+        ));
+        assert_eq!(coalescing_edit(&(2..2), "", false), None);
+    }
+
+    #[test]
+    fn undo_history_discards_only_the_oldest_snapshot_at_the_limit() {
+        let mut history = VecDeque::new();
+        for index in 0..=UNDO_LIMIT {
+            push_undo_snapshot(
+                &mut history,
+                EditSnapshot {
+                    content: index.to_string(),
+                    selected_range: index..index,
+                    selection_reversed: false,
+                },
+            );
+        }
+
+        assert_eq!(history.len(), UNDO_LIMIT);
+        assert_eq!(history.front().unwrap().content, "1");
+        assert_eq!(history.back().unwrap().content, UNDO_LIMIT.to_string());
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)] // These fixtures produce exactly representable values.
+    fn drag_autoscroll_is_edge_proportional_and_capped_to_one_line() {
+        let line_height = 20.0;
+        assert_eq!(drag_scroll_delta(200.0, 100.0, 300.0, line_height), 0.0);
+        assert_eq!(drag_scroll_delta(90.0, 100.0, 300.0, line_height), -2.0);
+        assert_eq!(drag_scroll_delta(315.0, 100.0, 300.0, line_height), 3.0);
+        assert_eq!(drag_scroll_delta(-100.0, 100.0, 300.0, line_height), -20.0);
+        assert_eq!(drag_scroll_delta(500.0, 100.0, 300.0, line_height), 20.0);
+    }
+
+    #[test]
+    fn multi_click_selects_word_then_all_and_does_not_arm_drag() {
+        assert_eq!(press_intent(1, false), PressIntent::PlaceCaret);
+        assert_eq!(press_intent(1, true), PressIntent::ExtendSelection);
+        assert_eq!(press_intent(2, false), PressIntent::SelectWord);
+        assert_eq!(press_intent(2, true), PressIntent::SelectWord);
+        assert_eq!(press_intent(3, false), PressIntent::SelectAll);
+        assert!(press_intent(1, false).arms_drag());
+        assert!(press_intent(1, true).arms_drag());
+        assert!(!press_intent(2, false).arms_drag());
+        assert!(!press_intent(3, false).arms_drag());
+    }
+}
+
+#[cfg(test)]
+mod history_budget_tests {
+    use super::*;
+    #[test]
+    fn an_oversized_edit_does_not_escape_the_history_byte_budget() {
+        let mut history = VecDeque::new();
+        push_undo_snapshot(
+            &mut history,
+            EditSnapshot {
+                content: "x".repeat(MAX_EDIT_HISTORY_BYTES + 1),
+                selected_range: 0..0,
+                selection_reversed: false,
+            },
+        );
+        assert!(history.is_empty());
     }
 }

--- a/crates/gpui-core/src/custom_elements/mod.rs
+++ b/crates/gpui-core/src/custom_elements/mod.rs
@@ -52,6 +52,7 @@ pub struct CustomRenderContext<'a> {
     /// tree never sees it and the build-time resolver cannot produce ranges for
     /// it. `ctx.text` matches the exact string it is about to paint instead,
     /// which makes drift between the search pass and the paint pass impossible.
+    pub props: &'a HashMap<String, serde_json::Value>,
     pub highlight_set: Option<std::sync::Arc<crate::text::HighlightContext>>,
 }
 
@@ -123,6 +124,7 @@ pub(crate) fn custom_surface(
         el = el.relative();
     }
     el = el.child(crate::automation::bounds_tracker(ctx.id, None));
+    el = crate::accessibility::apply_accessibility(el, ctx.props, None);
     wire_standard_events(el, ctx)
 }
 
@@ -136,14 +138,16 @@ pub(crate) fn wire_standard_events<E: gpui::StatefulInteractiveElement>(
         let callback = ctx.event_callback.clone();
         match event {
             "click" => {
-                el = el.on_click(move |click, _window, _cx| {
+                el = el.on_mouse_up(gpui::MouseButton::Left, move |click, _window, _cx| {
                     crate::renderer::emit_event_full(&callback, id, "click", |payload| {
-                        let (x, y) = crate::renderer::point_to_xy(click.position());
+                        let (x, y) = crate::renderer::point_to_xy(click.position);
+                        payload.button = Some(0);
+                        payload.is_right_click = Some(false);
                         payload.x = Some(x);
                         payload.y = Some(y);
                         payload.click_count =
-                            Some(u32::try_from(click.click_count()).unwrap_or(u32::MAX));
-                        payload.modifiers = Some(click.modifiers().into());
+                            Some(u32::try_from(click.click_count).unwrap_or(u32::MAX));
+                        payload.modifiers = Some(click.modifiers.into());
                     });
                 });
             }
@@ -165,7 +169,7 @@ pub(crate) fn wire_standard_events<E: gpui::StatefulInteractiveElement>(
             _ => {}
         }
     }
-    el
+    crate::accessibility::apply_a11y_click(el, ctx.events, ctx.id, ctx.event_callback.as_ref())
 }
 
 // ── Traits ───────────────────────────────────────────────────────────

--- a/crates/gpui-core/src/lib.rs
+++ b/crates/gpui-core/src/lib.rs
@@ -1,5 +1,6 @@
 // Keep the complete workspace lint policy active for the native engine.
 
+mod accessibility;
 #[cfg(target_os = "macos")]
 mod app_menu;
 mod audio;

--- a/crates/gpui-core/src/renderer.rs
+++ b/crates/gpui-core/src/renderer.rs
@@ -102,13 +102,37 @@ impl std::error::Error for Error {}
 #[cfg(target_family = "wasm")]
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
-gpui::actions!(gpui_vue_focus, [FocusNext, FocusPrevious]);
+const SELECTION_SCROLL_TICK_MS: u64 = 24;
+const SELECTION_SCROLL_EDGE_PX: f32 = 36.0;
+const SELECTION_SCROLL_MAX_STEP_PX: f32 = 24.0;
 
-pub(crate) fn init_key_bindings(cx: &mut gpui::App) {
-    cx.bind_keys([
-        gpui::KeyBinding::new("tab", FocusNext, None),
-        gpui::KeyBinding::new("shift-tab", FocusPrevious, None),
-    ]);
+/// Signed list scroll step for a pointer near a viewport edge.
+fn selection_scroll_step(
+    bounds: gpui::Bounds<gpui::Pixels>,
+    position: gpui::Point<gpui::Pixels>,
+) -> f32 {
+    let height = f32::from(bounds.size.height);
+    if height <= 0.0 {
+        return 0.0;
+    }
+    let edge = SELECTION_SCROLL_EDGE_PX.min(height / 6.0);
+    if edge <= 0.0 {
+        return 0.0;
+    }
+    let y = f32::from(position.y);
+    let top = f32::from(bounds.top());
+    let bottom = f32::from(bounds.bottom());
+    let scaled = |penetration: f32| {
+        let progress = (penetration / edge).clamp(0.0, 1.0);
+        SELECTION_SCROLL_MAX_STEP_PX * progress * progress
+    };
+    if y < top + edge {
+        -scaled(top + edge - y)
+    } else if y > bottom - edge {
+        scaled(y - (bottom - edge))
+    } else {
+        0.0
+    }
 }
 
 /// The Window menu items act on the focused window, and the root element is the
@@ -466,6 +490,13 @@ enum UiCommand {
         response: SyncSender<Option<crate::automation::ElementBounds>>,
     },
     FocusElement(u64),
+    FocusNext,
+    FocusPrevious,
+    SetWindowKeyEvents {
+        key_down: bool,
+        key_up: bool,
+        event_id: u64,
+    },
     ControlClock {
         control: ClockControl,
         response: SyncSender<f64>,
@@ -504,6 +535,35 @@ enum ThreadedAppCommand {
     Open(OpenWindowRequest),
 }
 
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code, reason = "Win32 DPI setup has no safe wrapper in GPUI")]
+fn enable_per_monitor_dpi() {
+    use windows::Win32::UI::HiDpi::{
+        AreDpiAwarenessContextsEqual, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE,
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, GetThreadDpiAwarenessContext,
+        SetProcessDpiAwarenessContext, SetThreadDpiAwarenessContext,
+    };
+
+    // SAFETY: Called only on the GPUI UI thread before it creates any HWND.
+    // All arguments are documented constant DPI awareness handles.
+    unsafe {
+        let current = GetThreadDpiAwarenessContext();
+        if AreDpiAwarenessContextsEqual(current, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+            .as_bool()
+        {
+            return;
+        }
+        if SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2).is_ok() {
+            return;
+        }
+        if SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE).is_ok() {
+            return;
+        }
+        // Process awareness is already locked (node/bun manifest). This thread has no HWND yet.
+        SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
+}
+
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
 fn threaded_app_sender() -> Result<mpsc::UnboundedSender<ThreadedAppCommand>> {
     static SENDER: OnceLock<Mutex<Option<mpsc::UnboundedSender<ThreadedAppCommand>>>> =
@@ -520,12 +580,14 @@ fn threaded_app_sender() -> Result<mpsc::UnboundedSender<ThreadedAppCommand>> {
     std::thread::Builder::new()
         .name("gpui_vue-ui".to_string())
         .spawn(move || {
+            #[cfg(target_os = "windows")]
+            enable_per_monitor_dpi();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 gpui_platform::application()
                     .with_quit_mode(gpui::QuitMode::Explicit)
                     .run(move |cx| {
-                        init_key_bindings(cx);
                         crate::custom_elements::input::init(cx);
+                        crate::custom_elements::img::init(cx);
                         cx.spawn(async move |cx| {
                             run_threaded_app_commands(receiver, cx).await;
                         })
@@ -814,6 +876,21 @@ async fn run_ui_commands(
                 cx.notify();
                 window.refresh();
             }),
+            UiCommand::FocusNext => gpui::AnyWindowHandle::from(window)
+                .update(cx, |_, window, cx| window.focus_next(cx)),
+            UiCommand::FocusPrevious => gpui::AnyWindowHandle::from(window)
+                .update(cx, |_, window, cx| window.focus_prev(cx)),
+            UiCommand::SetWindowKeyEvents {
+                key_down,
+                key_up,
+                event_id,
+            } => window.update(cx, move |view, window, cx| {
+                view.window_key_down = key_down;
+                view.window_key_up = key_up;
+                view.window_key_event_id = event_id;
+                cx.notify();
+                window.refresh();
+            }),
             UiCommand::ControlClock { control, response } => {
                 window.update(cx, move |view, _window, cx| {
                     let now_ms = match control {
@@ -827,58 +904,67 @@ async fn run_ui_commands(
                 })
             }
             UiCommand::DispatchMouse { input, response } => {
-                let result = window.update(cx, move |_view, window, cx| match input {
-                    MouseInput::Click {
-                        x,
-                        y,
-                        button,
-                        modifiers,
-                    } => {
-                        crate::automation::dispatch_click(window, cx, x, y, button, modifiers);
-                    }
-                    MouseInput::Down {
-                        x,
-                        y,
-                        button,
-                        modifiers,
-                    } => {
-                        crate::automation::dispatch_mouse_down(window, cx, x, y, button, modifiers);
-                    }
-                    MouseInput::Up {
-                        x,
-                        y,
-                        button,
-                        modifiers,
-                    } => {
-                        crate::automation::dispatch_mouse_up(window, cx, x, y, button, modifiers);
-                    }
-                    MouseInput::Move {
-                        x,
-                        y,
-                        pressed_button,
-                        modifiers,
-                    } => {
-                        crate::automation::dispatch_mouse_move(
-                            window,
-                            cx,
-                            x,
-                            y,
-                            pressed_button,
-                            modifiers,
-                        );
-                    }
-                    MouseInput::Wheel {
-                        x,
-                        y,
-                        delta_x,
-                        delta_y,
-                        modifiers,
-                    } => {
-                        crate::automation::dispatch_scroll_wheel(
-                            window, cx, x, y, delta_x, delta_y, modifiers,
-                        );
-                    }
-                });
+                let result =
+                    gpui::AnyWindowHandle::from(window).update(cx, move |_view, window, cx| {
+                        match input {
+                            MouseInput::Click {
+                                x,
+                                y,
+                                button,
+                                modifiers,
+                            } => {
+                                crate::automation::dispatch_click(
+                                    window, cx, x, y, button, modifiers,
+                                );
+                            }
+                            MouseInput::Down {
+                                x,
+                                y,
+                                button,
+                                modifiers,
+                            } => {
+                                crate::automation::dispatch_mouse_down(
+                                    window, cx, x, y, button, modifiers,
+                                );
+                            }
+                            MouseInput::Up {
+                                x,
+                                y,
+                                button,
+                                modifiers,
+                            } => {
+                                crate::automation::dispatch_mouse_up(
+                                    window, cx, x, y, button, modifiers,
+                                );
+                            }
+                            MouseInput::Move {
+                                x,
+                                y,
+                                pressed_button,
+                                modifiers,
+                            } => {
+                                crate::automation::dispatch_mouse_move(
+                                    window,
+                                    cx,
+                                    x,
+                                    y,
+                                    pressed_button,
+                                    modifiers,
+                                );
+                            }
+                            MouseInput::Wheel {
+                                x,
+                                y,
+                                delta_x,
+                                delta_y,
+                                modifiers,
+                            } => {
+                                crate::automation::dispatch_scroll_wheel(
+                                    window, cx, x, y, delta_x, delta_y, modifiers,
+                                );
+                            }
+                        }
+                    });
                 response
                     .send(
                         result
@@ -981,6 +1067,12 @@ impl Drop for GpuiRenderer {
 // ── GPUI View ────────────────────────────────────────────────────────
 
 pub(crate) struct GpuiView {
+    pub(crate) window_key_down: bool,
+    pub(crate) window_key_up: bool,
+    pub(crate) window_key_event_id: u64,
+    selection_drag_position: Option<gpui::Point<gpui::Pixels>>,
+    selection_scroll_list: Option<u64>,
+    selection_scroll_task: Option<gpui::Task<()>>,
     pub(crate) tree: Arc<Mutex<RetainedTree>>,
     /// Structurally shared immutable tree used after the mutation lock is released.
     render_tree: Arc<RetainedTree>,
@@ -1131,6 +1223,108 @@ fn resolve_highlight(
 }
 
 impl GpuiView {
+    fn on_selection_mouse_move(
+        &mut self,
+        position: gpui::Point<gpui::Pixels>,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        if !self.selection.lock().is_dragging() {
+            self.stop_selection_scroll();
+            return;
+        }
+        let list_id = self
+            .selection_scroll_list
+            .filter(|id| {
+                self.virtual_lists.get(id).is_some_and(|entry| {
+                    let bounds = entry.state.viewport_bounds();
+                    position.x >= bounds.left() && position.x <= bounds.right()
+                })
+            })
+            .or_else(|| {
+                self.virtual_lists
+                    .iter()
+                    .find(|(_, entry)| entry.state.viewport_bounds().contains(&position))
+                    .map(|(id, _)| *id)
+            });
+        let Some(list_id) = list_id else {
+            self.stop_selection_scroll();
+            return;
+        };
+        self.selection_drag_position = Some(position);
+        self.selection_scroll_list = Some(list_id);
+        self.schedule_selection_scroll(cx);
+    }
+
+    fn stop_selection_scroll(&mut self) {
+        self.selection_drag_position = None;
+        self.selection_scroll_list = None;
+        self.selection_scroll_task = None;
+    }
+
+    fn schedule_selection_scroll(&mut self, cx: &mut gpui::Context<Self>) {
+        if self.selection_scroll_task.is_some() || !self.selection.lock().is_dragging() {
+            return;
+        }
+        let (Some(position), Some(list_id)) =
+            (self.selection_drag_position, self.selection_scroll_list)
+        else {
+            return;
+        };
+        let Some(entry) = self.virtual_lists.get(&list_id) else {
+            return;
+        };
+        if selection_scroll_step(entry.state.viewport_bounds(), position) == 0.0 {
+            return;
+        }
+        self.selection_scroll_task = Some(cx.spawn(async move |view, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_millis(SELECTION_SCROLL_TICK_MS))
+                .await;
+            if let Err(error) = view.update(cx, |view, cx| {
+                view.selection_scroll_task = None;
+                view.step_selection_scroll(cx);
+            }) {
+                log::debug!("selection scroll stopped after view teardown: {error}");
+            }
+        }));
+    }
+
+    fn step_selection_scroll(&mut self, cx: &mut gpui::Context<Self>) {
+        if !self.selection.lock().is_dragging() {
+            self.stop_selection_scroll();
+            return;
+        }
+        let (Some(position), Some(list_id)) =
+            (self.selection_drag_position, self.selection_scroll_list)
+        else {
+            return;
+        };
+        let Some(entry) = self.virtual_lists.get(&list_id) else {
+            self.stop_selection_scroll();
+            return;
+        };
+        let step = selection_scroll_step(entry.state.viewport_bounds(), position);
+        if step == 0.0 {
+            return;
+        }
+
+        let before = entry.state.logical_scroll_top();
+        let selection_moved = crate::text::paint::update_drag_at(&self.selection, position);
+        entry.state.scroll_by(gpui::px(step));
+        let after = entry.state.logical_scroll_top();
+        let list_moved =
+            after.item_ix != before.item_ix || after.offset_in_item != before.offset_in_item;
+        if !selection_moved && !list_moved {
+            self.stop_selection_scroll();
+            return;
+        }
+        cx.notify();
+        self.schedule_selection_scroll(cx);
+    }
+
+    /// Sync focus handles with the current element tree.
+    /// Creates handles for new focusable elements, subscribes `on_focus/on_blur`,
+    /// and cleans up handles for destroyed elements.
     pub(crate) fn new(
         tree: Arc<Mutex<RetainedTree>>,
         event_callback: Option<EventCallback>,
@@ -1149,6 +1343,12 @@ impl GpuiView {
             scroll_handles: HashMap::new(),
             motion_states: HashMap::new(),
             selection,
+            window_key_down: false,
+            window_key_up: false,
+            window_key_event_id: 0,
+            selection_drag_position: None,
+            selection_scroll_list: None,
+            selection_scroll_task: None,
             virtual_lists: HashMap::new(),
             clock,
             highlights: HashMap::new(),
@@ -1542,6 +1742,7 @@ impl GpuiView {
 }
 
 impl gpui::Render for GpuiView {
+    #[allow(clippy::too_many_lines)]
     fn render(
         &mut self,
         window: &mut gpui::Window,
@@ -1628,12 +1829,28 @@ impl gpui::Render for GpuiView {
         // longer on screen.
         let result = {
             use gpui::prelude::*;
-            let root = gpui::div()
-                .size_full()
-                .on_action(|_: &FocusNext, window, cx| window.focus_next(cx))
-                .on_action(|_: &FocusPrevious, window, cx| window.focus_prev(cx));
+            let drag_move_view = cx.entity().downgrade();
+            let drag_end_view = cx.entity().downgrade();
+            let root = gpui::div().size_full().child(window_key_events(
+                callback.clone(),
+                self.window_key_down,
+                self.window_key_up,
+                self.window_key_event_id,
+            ));
             with_window_menu_actions(root)
-                .child(selection_frame_reset(self.selection.clone()))
+                .child(selection_frame_reset(
+                    self.selection.clone(),
+                    move |position, app| {
+                        drag_move_view
+                            .update(app, |view, cx| view.on_selection_mouse_move(position, cx))
+                            .ok();
+                    },
+                    move |app| {
+                        drag_end_view
+                            .update(app, |view, _cx| view.stop_selection_scroll())
+                            .ok();
+                    },
+                ))
                 .child(crate::automation::bounds_frame_reset())
                 .child(result)
                 .into_any_element()
@@ -1714,10 +1931,10 @@ impl EdgeInsets {
     #[cfg(any(target_os = "macos", target_family = "wasm"))]
     fn from_gpui(insets: gpui::Edges<gpui::Pixels>) -> Self {
         Self {
-            top: f32::from(insets.top) as f64,
-            right: f32::from(insets.right) as f64,
-            bottom: f32::from(insets.bottom) as f64,
-            left: f32::from(insets.left) as f64,
+            top: f64::from(f32::from(insets.top)),
+            right: f64::from(f32::from(insets.right)),
+            bottom: f64::from(f32::from(insets.bottom)),
+            left: f64::from(f32::from(insets.left)),
         }
     }
 }
@@ -2326,4 +2543,56 @@ mod batch_tests {
         tree.styles.sweep();
         assert_eq!(tree.styles.len(), 0);
     }
+}
+
+fn window_key_events(
+    callback: Option<EventCallback>,
+    key_down: bool,
+    key_up: bool,
+    event_id: u64,
+) -> impl gpui::IntoElement {
+    use gpui::prelude::*;
+
+    gpui::canvas(
+        |_, _, _| (),
+        move |_, (), window, _| {
+            if key_down || cfg!(all(target_arch = "wasm32", target_os = "unknown")) {
+                let callback = callback.clone();
+                window.on_root_key_event(move |event: &gpui::KeyDownEvent, phase, _window, _cx| {
+                    if phase != gpui::DispatchPhase::Bubble {
+                        return;
+                    }
+                    if key_down {
+                        emit_event_full(&callback, event_id, "windowKeyDown", |payload| {
+                            payload.key = Some(event.keystroke.key.clone());
+                            payload.key_char.clone_from(&event.keystroke.key_char);
+                            payload.is_held = Some(event.is_held);
+                            payload.modifiers = Some(event.keystroke.modifiers.into());
+                        });
+                    }
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+                    if event.keystroke.key == "tab" {
+                        // Keep browser focus on GPUI's hidden keyboard element.
+                        _cx.stop_propagation();
+                    }
+                });
+            }
+            if key_up {
+                let callback = callback.clone();
+                window.on_root_key_event(move |event: &gpui::KeyUpEvent, phase, _window, _cx| {
+                    if phase != gpui::DispatchPhase::Bubble {
+                        return;
+                    }
+                    emit_event_full(&callback, event_id, "windowKeyUp", |payload| {
+                        payload.key = Some(event.keystroke.key.clone());
+                        payload.key_char.clone_from(&event.keystroke.key_char);
+                        payload.modifiers = Some(event.keystroke.modifiers.into());
+                    });
+                });
+            }
+        },
+    )
+    .absolute()
+    .w(gpui::px(0.0))
+    .h(gpui::px(0.0))
 }

--- a/crates/gpui-core/src/renderer/api.rs
+++ b/crates/gpui-core/src/renderer/api.rs
@@ -136,8 +136,8 @@ impl GpuiRenderer {
 
         let application = gpui_platform::single_threaded_web();
         let application_handle = application.run_embedded(move |cx: &mut gpui::App| {
-            init_key_bindings(cx);
             crate::custom_elements::input::init(cx);
+            crate::custom_elements::img::init(cx);
             let bounds = gpui::Bounds::centered(
                 None,
                 gpui::size(gpui::px(width as f32), gpui::px(height as f32)),
@@ -184,6 +184,7 @@ impl GpuiRenderer {
     }
 
     #[cfg(target_os = "macos")]
+    #[allow(clippy::too_many_lines)]
     fn init_macos(&self, options: Option<WindowOptions>) -> Result<()> {
         let options = options.unwrap_or_default();
 
@@ -226,8 +227,8 @@ impl GpuiRenderer {
         let app = gpui::Application::with_platform(platform.clone())
             .with_quit_mode(gpui::QuitMode::LastWindowClosed);
         let app_handle = app.run_embedded(move |cx: &mut gpui::App| {
-            init_key_bindings(cx);
             crate::custom_elements::input::init(cx);
+            crate::custom_elements::img::init(cx);
             // After the other bindings: `set_menus` reads key equivalents out of
             // the keymap, so every binding must exist before it runs.
             crate::app_menu::init(&app_name, cx);
@@ -517,10 +518,9 @@ impl GpuiRenderer {
             let running = MAC_PLATFORM.with(|p| {
                 p.borrow()
                     .as_ref()
-                    .map(|platform| platform.pump_events())
-                    .unwrap_or(false)
+                    .is_some_and(|platform| platform.pump_events())
             });
-            return Ok(running);
+            Ok(running)
         }
 
         #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
@@ -569,8 +569,8 @@ impl GpuiRenderer {
         return update_window(|_view, window, _cx| {
             let size = window.viewport_size();
             WindowSize {
-                width: f32::from(size.width) as f64,
-                height: f32::from(size.height) as f64,
+                width: f64::from(f32::from(size.width)),
+                height: f64::from(f32::from(size.height)),
             }
         });
 
@@ -754,6 +754,7 @@ impl GpuiRenderer {
         self.debug_frame_overlay_mode()
     }
 
+    #[allow(clippy::unused_self)] // N-API instance method over thread-local renderer state.
     fn debug_frame_overlay_mode(&self) -> Result<String> {
         #[cfg(target_os = "macos")]
         return update_window(|_view, window, _cx| {
@@ -940,6 +941,60 @@ impl GpuiRenderer {
             target_family = "wasm"
         )))]
         Err(Error::from_reason("Unsupported operating system"))
+    }
+
+    #[cfg_attr(not(target_family = "wasm"), napi)]
+    pub fn focus_next(&self) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        return update_window_without_view(gpui::Window::focus_next);
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.send_ui_command(UiCommand::FocusNext);
+        #[cfg(target_family = "wasm")]
+        return update_web_window_without_view(self.web_renderer_id, |window, cx| {
+            window.focus_next(cx)
+        })
+        .map(|_| ());
+    }
+
+    #[cfg_attr(not(target_family = "wasm"), napi)]
+    pub fn focus_previous(&self) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        return update_window_without_view(gpui::Window::focus_prev);
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.send_ui_command(UiCommand::FocusPrevious);
+        #[cfg(target_family = "wasm")]
+        return update_web_window_without_view(self.web_renderer_id, |window, cx| {
+            window.focus_prev(cx)
+        })
+        .map(|_| ());
+    }
+
+    #[cfg_attr(not(target_family = "wasm"), napi)]
+    pub fn set_window_key_events(&self, key_down: bool, key_up: bool, event_id: f64) -> Result<()> {
+        let event_id = to_element_id(event_id)?;
+        #[cfg(target_os = "macos")]
+        return update_window(move |view, window, cx| {
+            view.window_key_down = key_down;
+            view.window_key_up = key_up;
+            view.window_key_event_id = event_id;
+            cx.notify();
+            window.refresh();
+        });
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.send_ui_command(UiCommand::SetWindowKeyEvents {
+            key_down,
+            key_up,
+            event_id,
+        });
+        #[cfg(target_family = "wasm")]
+        return update_web_window(self.web_renderer_id, move |view, window, cx| {
+            view.window_key_down = key_down;
+            view.window_key_up = key_up;
+            view.window_key_event_id = event_id;
+            cx.notify();
+            window.refresh();
+        })
+        .map(|_| ());
     }
 
     #[cfg_attr(not(target_family = "wasm"), napi)]
@@ -1554,10 +1609,10 @@ impl GpuiRenderer {
                 window.refresh();
                 window.render_to_image()
             })?
-            .map_err(|e| Error::from_reason(format!("Screenshot capture failed: {}", e)))?;
+            .map_err(|e| Error::from_reason(format!("Screenshot capture failed: {e}")))?;
             image
                 .save(&path)
-                .map_err(|e| Error::from_reason(format!("Failed to save screenshot: {}", e)))?;
+                .map_err(|e| Error::from_reason(format!("Failed to save screenshot: {e}")))?;
             Ok(())
         }
 

--- a/crates/gpui-core/src/renderer/backend.rs
+++ b/crates/gpui-core/src/renderer/backend.rs
@@ -38,9 +38,10 @@ impl Backend for GpuiRenderer {
             .map_err(|_| Error::from_reason("The GPUI UI thread is not running"))
     }
 
+    #[allow(clippy::too_many_lines)] // Platform dispatch paths share one automation contract.
     fn dispatch_mouse_input(&self, input: MouseInput) -> Result<()> {
         #[cfg(target_os = "macos")]
-        return update_window(move |_view, window, cx| match input {
+        return update_window_without_view(move |window, cx| match input {
             MouseInput::Click {
                 x,
                 y,
@@ -65,7 +66,7 @@ impl Backend for GpuiRenderer {
                 pressed_button,
                 modifiers,
             } => {
-                crate::automation::dispatch_mouse_move(window, cx, x, y, pressed_button, modifiers)
+                crate::automation::dispatch_mouse_move(window, cx, x, y, pressed_button, modifiers);
             }
             MouseInput::Wheel {
                 x,
@@ -89,43 +90,51 @@ impl Backend for GpuiRenderer {
         }
 
         #[cfg(target_family = "wasm")]
-        return update_web_window(self.web_renderer_id, move |_view, window, cx| match input {
-            MouseInput::Click {
-                x,
-                y,
-                button,
-                modifiers,
-            } => crate::automation::dispatch_click(window, cx, x, y, button, modifiers),
-            MouseInput::Down {
-                x,
-                y,
-                button,
-                modifiers,
-            } => crate::automation::dispatch_mouse_down(window, cx, x, y, button, modifiers),
-            MouseInput::Up {
-                x,
-                y,
-                button,
-                modifiers,
-            } => crate::automation::dispatch_mouse_up(window, cx, x, y, button, modifiers),
-            MouseInput::Move {
-                x,
-                y,
-                pressed_button,
-                modifiers,
-            } => {
-                crate::automation::dispatch_mouse_move(window, cx, x, y, pressed_button, modifiers)
-            }
-            MouseInput::Wheel {
-                x,
-                y,
-                delta_x,
-                delta_y,
-                modifiers,
-            } => crate::automation::dispatch_scroll_wheel(
-                window, cx, x, y, delta_x, delta_y, modifiers,
-            ),
-        })
+        return update_web_window_without_view(
+            self.web_renderer_id,
+            move |window, cx| match input {
+                MouseInput::Click {
+                    x,
+                    y,
+                    button,
+                    modifiers,
+                } => crate::automation::dispatch_click(window, cx, x, y, button, modifiers),
+                MouseInput::Down {
+                    x,
+                    y,
+                    button,
+                    modifiers,
+                } => crate::automation::dispatch_mouse_down(window, cx, x, y, button, modifiers),
+                MouseInput::Up {
+                    x,
+                    y,
+                    button,
+                    modifiers,
+                } => crate::automation::dispatch_mouse_up(window, cx, x, y, button, modifiers),
+                MouseInput::Move {
+                    x,
+                    y,
+                    pressed_button,
+                    modifiers,
+                } => crate::automation::dispatch_mouse_move(
+                    window,
+                    cx,
+                    x,
+                    y,
+                    pressed_button,
+                    modifiers,
+                ),
+                MouseInput::Wheel {
+                    x,
+                    y,
+                    delta_x,
+                    delta_y,
+                    modifiers,
+                } => crate::automation::dispatch_scroll_wheel(
+                    window, cx, x, y, delta_x, delta_y, modifiers,
+                ),
+            },
+        )
         .map(|_| ());
 
         #[cfg(not(any(

--- a/crates/gpui-core/src/renderer/build.rs
+++ b/crates/gpui-core/src/renderer/build.rs
@@ -103,6 +103,7 @@ pub(crate) fn build_element(
                 selection: ctx.selection.clone(),
                 selectable: inherited.selectable,
                 selection_wash: inherited.selection_wash,
+                props: &element.custom_props,
                 highlight_set: inherited.highlight.clone(),
             };
             ctx.custom_registry
@@ -112,6 +113,28 @@ pub(crate) fn build_element(
 
     ctx.inherited = parent_inherited;
     built
+}
+
+fn joined_text_content(
+    tree: &RetainedTree,
+    element: &crate::retained_tree::RetainedElement,
+) -> Option<String> {
+    if let Some(content) = element.content.as_deref().filter(|value| !value.is_empty()) {
+        return Some(content.to_string());
+    }
+    let mut parts = Vec::new();
+    for child_id in &element.children {
+        let Some(child) = tree.elements.get(child_id) else {
+            continue;
+        };
+        if child.element_type == "text"
+            && let Some(content) = child.content.as_deref()
+        {
+            parts.push(content);
+        }
+    }
+    let joined = parts.concat();
+    (!joined.is_empty()).then_some(joined)
 }
 
 #[allow(
@@ -249,12 +272,16 @@ fn build_virtual_list(
         };
         view.build_virtual_child(list_id, index, child_id, inherited.clone(), window, cx)
     });
-    let mut list =
-        gpui::list(list_state, render_item).with_sizing_behavior(gpui::ListSizingBehavior::Auto);
+    let mut list = gpui::list(list_state, render_item)
+        .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
+        .id(super::super::custom_elements::custom_element_id(
+            "gpui_virtual_list",
+            element.id,
+        ));
     if let Some(style) = element.style.as_deref() {
         list = apply_styles(list, style);
     }
-    list.into_any_element()
+    crate::accessibility::apply_accessibility(list, &element.custom_props, None).into_any_element()
 }
 
 pub(super) fn unmounted_virtual_row(height: f32) -> gpui::AnyElement {
@@ -385,10 +412,45 @@ pub(crate) fn build_host_container(
         el = el.tab_index(tab_index).tab_stop(tab_index >= 0);
     }
 
+    let is_text_host = element.element_type == "text" && element.content.is_none();
+    let default_role = is_text_host.then_some(gpui::Role::Label);
+    el = crate::accessibility::apply_accessibility(el, &element.custom_props, default_role);
+    if is_text_host
+        && !element.custom_props.contains_key("aria-valuetext")
+        && let Some(content) = joined_text_content(ctx.tree, element)
+    {
+        el = el.aria_value(content);
+    }
+
     // Wire up events.
-    // Some events (on_hover, on_click) require a stateful element (.id()),
+    // Some events (on_hover, on_aux_click) require a stateful element (.id()),
     // which we already set above. Others (on_mouse_down, on_key_down) work
     // on any InteractiveElement.
+    if element.events.contains("click") {
+        let id = element.id;
+        let callback = ctx.event_callback.clone();
+        // GPUI's higher-level on_click gesture is not finalized by the
+        // embedded macOS pump. Bubble listeners run in reverse registration
+        // order, so attach click first to keep onMouseUp ahead of onClick.
+        el = el.on_mouse_up(gpui::MouseButton::Left, move |mouse_event, _window, _cx| {
+            emit_event_full(&callback, id, "click", |p| {
+                let (x, y) = point_to_xy(mouse_event.position);
+                p.x = Some(x);
+                p.y = Some(y);
+                p.button = Some(0);
+                p.modifiers = Some(mouse_event.modifiers.into());
+                p.click_count = Some(mouse_event.click_count as u32);
+                p.is_right_click = Some(false);
+            });
+        });
+        el = crate::accessibility::apply_a11y_click(
+            el,
+            &element.events,
+            id,
+            ctx.event_callback.as_ref(),
+        );
+    }
+
     for event_type in element.events.iter() {
         let id = element.id;
         let callback = ctx.event_callback.clone();
@@ -396,19 +458,6 @@ pub(crate) fn build_host_container(
             // ── Click ────────────────────────────────────────────
             // Primary button only, like the DOM. Right and middle clicks go to
             // `onAuxClick`, and `onMouseDown` sees every button.
-            "click" => {
-                el = el.on_click(move |click_event, _window, _cx| {
-                    emit_event_full(&callback, id, "click", |p| {
-                        let (x, y) = point_to_xy(click_event.position());
-                        p.x = Some(x);
-                        p.y = Some(y);
-                        p.modifiers = Some(click_event.modifiers().into());
-                        p.click_count = Some(click_event.click_count() as u32);
-                        p.is_right_click = Some(click_event.is_right_click());
-                    });
-                });
-            }
-
             // ── Aux click (non-primary), like the DOM `auxclick` ──
             "auxClick" => {
                 el = el.on_aux_click(move |click_event, _window, _cx| {

--- a/crates/gpui-core/src/renderer/styles.rs
+++ b/crates/gpui-core/src/renderer/styles.rs
@@ -272,6 +272,12 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     }
     // `line_height` was accepted by the style type but never applied, so
     // multi-line text always used gpui's default leading.
+    match style.text_decoration.as_deref() {
+        Some("underline") => el = el.underline(),
+        Some("line-through") => el = el.line_through(),
+        Some("none") => el = el.text_decoration_none(),
+        _ => {}
+    }
     if let Some(line_height) = style.line_height
         && line_height > 0.0
     {

--- a/crates/gpui-core/src/renderer/wasm.rs
+++ b/crates/gpui-core/src/renderer/wasm.rs
@@ -115,6 +115,28 @@ impl WebGpuiRenderer {
         self.inner.focus_element(element_id).map_err(js_error)
     }
 
+    #[wasm_bindgen(js_name = focusNext)]
+    pub fn focus_next(&self) -> Result<(), JsValue> {
+        self.inner.focus_next().map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = focusPrevious)]
+    pub fn focus_previous(&self) -> Result<(), JsValue> {
+        self.inner.focus_previous().map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = setWindowKeyEvents)]
+    pub fn set_window_key_events(
+        &self,
+        key_down: bool,
+        key_up: bool,
+        event_id: f64,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .set_window_key_events(key_down, key_up, event_id)
+            .map_err(js_error)
+    }
+
     pub fn blur(&self) -> Result<(), JsValue> {
         self.inner.blur().map_err(js_error)
     }

--- a/crates/gpui-core/src/style.rs
+++ b/crates/gpui-core/src/style.rs
@@ -132,7 +132,7 @@ pub(crate) fn parse_font_weight(value: &FontWeightValue) -> gpui::FontWeight {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ResolvedStyle {
     initialized: bool,
-    background: Option<gpui::Rgba>,
+    background: Option<gpui::Background>,
     color: Option<gpui::Rgba>,
     border_color: Option<gpui::Rgba>,
     shadow_color: Option<gpui::Rgba>,
@@ -155,6 +155,32 @@ pub struct ResolvedStyle {
     pub(crate) text_overflow: Option<TextOverflowValue>,
     pub(crate) font_weight: Option<gpui::FontWeight>,
     pub(crate) visible: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearGradientStopValue {
+    pub color: String,
+    pub position: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum GradientValue {
+    #[serde(rename = "linear-gradient")]
+    LinearGradient {
+        angle: f64,
+        stops: [LinearGradientStopValue; 2],
+        #[serde(rename = "colorSpace")]
+        color_space: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BackgroundValue {
+    Color(String),
+    Gradient(Box<GradientValue>),
 }
 
 /// A dimension value that can be a number (pixels) or a string (percentage, auto, etc.)
@@ -305,7 +331,7 @@ pub struct StyleDesc {
     pub left: Option<f64>,
 
     // Background & Colors
-    pub background: Option<String>,
+    pub background: Option<BackgroundValue>,
     pub background_color: Option<String>,
     pub color: Option<String>,
     pub opacity: Option<f64>,
@@ -333,6 +359,7 @@ pub struct StyleDesc {
     pub white_space: Option<String>,
     pub text_overflow: Option<String>,
     pub line_clamp: Option<f64>,
+    pub text_decoration: Option<String>,
 
     // Overflow
     pub overflow: Option<String>,
@@ -367,11 +394,7 @@ pub struct StyleDesc {
 
 impl StyleDesc {
     pub(crate) fn resolve_cached_values(&mut self) {
-        let background = self
-            .background_color
-            .as_deref()
-            .or(self.background.as_deref())
-            .and_then(crate::color::parse_color_rgba);
+        let background = self.resolve_background_value();
         self.resolved = ResolvedStyle {
             initialized: true,
             background,
@@ -422,14 +445,18 @@ impl StyleDesc {
         }
     }
 
-    pub(crate) fn resolved_background(&self) -> Option<gpui::Rgba> {
+    fn resolve_background_value(&self) -> Option<gpui::Background> {
+        if let Some(value) = self.background_color.as_deref() {
+            return crate::color::parse_color_rgba(value).map(Into::into);
+        }
+        self.background.as_ref()?.resolve()
+    }
+
+    pub(crate) fn resolved_background(&self) -> Option<gpui::Background> {
         if self.resolved.initialized {
             self.resolved.background
         } else {
-            self.background_color
-                .as_deref()
-                .or(self.background.as_deref())
-                .and_then(crate::color::parse_color_rgba)
+            self.resolve_background_value()
         }
     }
 
@@ -742,7 +769,7 @@ pub fn should_occlude(style: &StyleDesc) -> bool {
         return false;
     }
     match style.resolved_background() {
-        Some(color) => color.a > 0.0,
+        Some(background) => !background.is_transparent(),
         None => true,
     }
 }
@@ -846,6 +873,103 @@ mod tests {
     fn dimensions_reject_non_finite_strings() {
         for value in [r#""NaN""#, r#""inf""#, r#""NaN%""#] {
             assert!(serde_json::from_str::<DimensionValue>(value).is_err());
+        }
+    }
+}
+
+impl BackgroundValue {
+    fn resolve(&self) -> Option<gpui::Background> {
+        match self {
+            Self::Color(value) => crate::color::parse_color_rgba(value).map(Into::into),
+            Self::Gradient(gradient) => {
+                let GradientValue::LinearGradient {
+                    angle,
+                    stops,
+                    color_space,
+                } = gradient.as_ref();
+                let angle = *angle as f32;
+                let [from, to] = stops;
+                let from_position = from.position as f32;
+                let to_position = to.position as f32;
+                if !angle.is_finite()
+                    || !(0.0..=1.0).contains(&from_position)
+                    || !(0.0..=1.0).contains(&to_position)
+                {
+                    return None;
+                }
+
+                let color_space = match color_space.as_deref() {
+                    None | Some("srgb") => gpui::ColorSpace::Srgb,
+                    Some("oklab") => gpui::ColorSpace::Oklab,
+                    _ => return None,
+                };
+                Some(
+                    gpui::linear_gradient(
+                        angle,
+                        gpui::linear_color_stop(
+                            crate::color::parse_color_rgba(&from.color)?,
+                            from_position,
+                        ),
+                        gpui::linear_color_stop(
+                            crate::color::parse_color_rgba(&to.color)?,
+                            to_position,
+                        ),
+                    )
+                    .color_space(color_space),
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod upstream_gradient_tests {
+    use super::*;
+    #[test]
+    fn resolves_a_two_stop_linear_gradient() {
+        let style: StyleDesc = serde_json::from_str(
+            r##"{"background":{"type":"linear-gradient","angle":90,"stops":[{"color":"#ff0000","position":0},{"color":"#0000ff","position":1}],"colorSpace":"oklab"}}"##,
+        )
+        .unwrap();
+        let expected = gpui::linear_gradient(
+            90.0,
+            gpui::linear_color_stop(crate::color::parse_color_rgba("#ff0000").unwrap(), 0.0),
+            gpui::linear_color_stop(crate::color::parse_color_rgba("#0000ff").unwrap(), 1.0),
+        )
+        .color_space(gpui::ColorSpace::Oklab);
+
+        assert_eq!(style.resolved_background(), Some(expected));
+    }
+
+    #[test]
+    fn transparent_gradient_does_not_occlude() {
+        let style: StyleDesc = serde_json::from_str(
+            r##"{"background":{"type":"linear-gradient","angle":0,"stops":[{"color":"transparent","position":0},{"color":"#00000000","position":1}]}}"##,
+        )
+        .unwrap();
+
+        assert!(!should_occlude(&style));
+    }
+
+    #[test]
+    fn cached_gradients_match_uncached_and_background_color_takes_precedence() {
+        let mut style: StyleDesc = serde_json::from_str(r#"{"background":{"type":"linear-gradient","angle":90,"stops":[{"color":"red","position":0},{"color":"blue","position":1}]}}"#).unwrap();
+        let original = style.resolved_background();
+        style.resolve_cached_values();
+        assert_eq!(style.resolved_background(), original);
+        style.background_color = Some("transparent".into());
+        style.resolve_cached_values();
+        assert!(style.resolved_background().unwrap().is_transparent());
+    }
+
+    #[test]
+    fn rejects_unsupported_gradient_color_space_and_stop_range() {
+        for gradient in [
+            r#"{"type":"linear-gradient","angle":0,"stops":[{"color":"red","position":-1},{"color":"blue","position":1}]}"#,
+            r#"{"type":"linear-gradient","angle":0,"stops":[{"color":"red","position":0},{"color":"blue","position":1}],"colorSpace":"invalid"}"#,
+        ] {
+            let background: BackgroundValue = serde_json::from_str(gradient).unwrap();
+            assert!(background.resolve().is_none());
         }
     }
 }

--- a/crates/gpui-core/src/test_renderer.rs
+++ b/crates/gpui-core/src/test_renderer.rs
@@ -1,15 +1,26 @@
+// N-API requires owned arguments and instance methods; GPUI test state is thread-local.
+// JS numbers are f64, while GPUI coordinates are f32. IDs are validated before use.
+#![allow(
+    clippy::unused_self,
+    clippy::needless_pass_by_value,
+    clippy::unnecessary_wraps,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
 use parking_lot::Mutex;
-/// TestGpuiRenderer — GPU-backed GPUI test renderer exposed to Node.js via napi.
+/// `TestGpuiRenderer` — GPU-backed GPUI test renderer exposed to Node.js via napi.
 ///
-/// Uses gpui::VisualTestAppContext with the native Metal or DirectX renderer
-/// and TestDispatcher for deterministic scheduling. Runs the SAME GpuiView,
-/// build_element(), apply_styles(), and event handlers as production.
+/// Uses `gpui::VisualTestAppContext` with the native Metal or DirectX renderer
+/// and `TestDispatcher` for deterministic scheduling. Runs the SAME `GpuiView`,
+/// `build_element()`, `apply_styles()`, and event handlers as production.
 ///
 /// Windows are positioned offscreen at (-10000, -10000) — invisible but
-/// fully rendered by the native GPU. This enables capture_screenshot() for visual
+/// fully rendered by the native GPU. This enables `capture_screenshot()` for visual
 /// test validation.
 ///
-/// VisualTestAppContext is !Send, so it is stored in thread-local state.
+/// `VisualTestAppContext` is !Send, so it is stored in thread-local state.
 /// All napi calls happen on the JS main thread.
 use std::cell::RefCell;
 use std::sync::Arc;
@@ -29,8 +40,8 @@ use crate::retained_tree::RetainedTree;
 
 // ── Thread-local storage for !Send GPUI types ────────────────────────
 
-/// Bundles VisualTestAppContext + window handle + view entity.
-/// Stored in thread_local because VisualTestAppContext is !Send (Rc<AppCell>).
+/// Bundles `VisualTestAppContext` + window handle + view entity.
+/// Stored in `thread_local` because `VisualTestAppContext` is !Send (Rc<AppCell>).
 /// Field order is load-bearing: Rust drops fields in declaration order, and
 /// gpui panics at app teardown if an `Entity` handle outlives its `App`.
 /// `view` must therefore be declared before `cx`.
@@ -82,9 +93,9 @@ thread_local! {
     static TEST_STATE: RefCell<Option<VisualTestState>> = const { RefCell::new(None) };
 }
 
-/// Access VisualTestAppContext + window + view mutably within thread_local.
-/// The closure receives (&mut cx, window_handle, &view_entity).
-/// Returns Err if no TestGpuiRenderer has been created on this thread.
+/// Access `VisualTestAppContext` + window + view mutably within `thread_local`.
+/// The closure receives (&mut cx, `window_handle`, &`view_entity`).
+/// Returns Err if no `TestGpuiRenderer` has been created on this thread.
 fn with_test_state<R>(
     f: impl FnOnce(
         &mut gpui::VisualTestAppContext,
@@ -127,7 +138,7 @@ fn window_dimension(value: Option<f64>, default: f64, label: &str) -> Result<f32
     Ok(pixels)
 }
 
-/// Convert JS button number (0=left, 1=middle, 2=right) to GPUI MouseButton.
+/// Convert JS button number (0=left, 1=middle, 2=right) to GPUI `MouseButton`.
 fn u32_to_mouse_button(button: u32) -> gpui::MouseButton {
     match button {
         1 => gpui::MouseButton::Middle,
@@ -138,24 +149,26 @@ fn u32_to_mouse_button(button: u32) -> gpui::MouseButton {
 
 // ── TestGpuiRenderer ────────────────────────────────────────────────
 
-/// GPU-backed GPUI test renderer. Uses VisualTestAppContext with the native
-/// Metal or DirectX renderer and TestDispatcher for deterministic scheduling.
-/// Same GpuiView and rendering pipeline as production.
+/// GPU-backed GPUI test renderer. Uses `VisualTestAppContext` with the native
+/// Metal or DirectX renderer and `TestDispatcher` for deterministic scheduling.
+/// Same `GpuiView` and rendering pipeline as production.
 ///
 /// Usage from JS:
-///   const r = new TestGpuiRenderer()
-///   r.createElement(1, "div")
-///   r.setRoot(1)
-///   r.commitMutations()
-///   r.flush()                  // triggers GpuiView::render() on the GPU
-///   r.simulateClick(50, 50)    // dispatches through GPUI hit testing
-///   const events = r.drainEvents()
-///   r.captureScreenshot("/tmp/test.png")  // saves rendered UI as PNG
+/// ```javascript
+/// const r = new TestGpuiRenderer()
+/// r.createElement(1, "div")
+/// r.setRoot(1)
+/// r.commitMutations()
+/// r.flush()                  // paints the retained view on the GPU
+/// r.simulateClick(50, 50)    // dispatches through GPUI hit testing
+/// const events = r.drainEvents()
+/// r.captureScreenshot("/tmp/test.png")
+/// ```
 #[napi]
 pub struct TestGpuiRenderer {
     tree: Arc<Mutex<RetainedTree>>,
     events: Arc<Mutex<Vec<EventPayload>>>,
-    /// Same handle GpuiView paints against, so tests can assert on the live
+    /// Same handle `GpuiView` paints against, so tests can assert on the live
     /// selection after simulating a drag.
     selection: crate::text::SharedSelection,
 }
@@ -186,7 +199,6 @@ impl TestGpuiRenderer {
         let platform = gpui_platform::current_platform(false);
         let mut cx = gpui::VisualTestAppContext::new(platform);
         cx.update(|cx| {
-            crate::renderer::init_key_bindings(cx);
             crate::custom_elements::input::init(cx);
         });
 
@@ -204,19 +216,25 @@ impl TestGpuiRenderer {
                     )
                 })
             })
-            .map_err(|e| Error::from_reason(format!("Failed to open test window: {}", e)))?;
+            .map_err(|e| Error::from_reason(format!("Failed to open test window: {e}")))?;
 
         // Get the root entity (Entity<GpuiView>) from the window.
         let view = window_handle
             .entity(&cx)
-            .map_err(|e| Error::from_reason(format!("Failed to get root view: {}", e)))?;
+            .map_err(|e| Error::from_reason(format!("Failed to get root view: {e}")))?;
 
         // Convert typed WindowHandle<GpuiView> to AnyWindowHandle for simulation methods.
         let window: gpui::AnyWindowHandle = window_handle.into();
 
+        cx.update_window(window, |_, window, _| {
+            window.set_a11y_active_for_tests(true);
+        })
+        .map_err(|error| Error::from_reason(error.to_string()))?;
+        cx.run_until_parked();
+
         // Store !Send types on the JS main thread.
         TEST_STATE.with(|cell| {
-            *cell.borrow_mut() = Some(VisualTestState { cx, window, view });
+            *cell.borrow_mut() = Some(VisualTestState { view, window, cx });
         });
 
         Ok(Self {
@@ -311,7 +329,7 @@ impl TestGpuiRenderer {
     pub fn set_custom_prop(&self, id: f64, key: String, value_json: String) -> Result<()> {
         let id = to_element_id(id)?;
         let value: serde_json::Value = serde_json::from_str(&value_json)
-            .map_err(|e| Error::from_reason(format!("Failed to parse custom prop value: {}", e)))?;
+            .map_err(|e| Error::from_reason(format!("Failed to parse custom prop value: {e}")))?;
         self.tree.lock().set_custom_prop(id, key, value);
         Ok(())
     }
@@ -327,14 +345,14 @@ impl TestGpuiRenderer {
     }
 
     /// Signal that a batch of mutations is complete.
-    /// In tests, this is a no-op — flush() handles the actual re-render.
+    /// In tests, this is a no-op — `flush()` handles the actual re-render.
     #[napi]
     pub fn commit_mutations(&self) -> Result<()> {
         Ok(())
     }
 
     /// Apply a batch of mutations in a single FFI call.
-    /// Same format as GpuiRenderer::apply_batch (string op names).
+    /// Same format as `GpuiRenderer::apply_batch` (string op names).
     /// Returns accumulated destroyed IDs from all destroyElement ops.
     #[napi]
     pub fn apply_batch(&self, json: String) -> Result<Vec<f64>> {
@@ -346,7 +364,7 @@ impl TestGpuiRenderer {
     // ── Test-specific methods ────────────────────────────────────────
 
     /// Notify the view entity and run GPUI until parked.
-    /// This triggers GpuiView::render() → build_element() → GPUI layout.
+    /// This triggers `GpuiView::render()` → `build_element()` → GPUI layout.
     /// Must be called after mutations and before simulating events (GPUI's
     /// hit testing requires elements to be laid out).
     #[napi]
@@ -366,9 +384,9 @@ impl TestGpuiRenderer {
     }
 
     /// Simulate a click at the given window coordinates.
-    /// Dispatches MouseDown + MouseUp through GPUI's input pipeline,
+    /// Dispatches `MouseDown` + `MouseUp` through GPUI's input pipeline,
     /// which triggers the same event handlers as production.
-    /// IMPORTANT: Call flush() before this — hit testing requires laid-out elements.
+    /// IMPORTANT: Call `flush()` before this — hit testing requires laid-out elements.
     /// `modifiers` uses the `press()` syntax: "cmd", "cmd-shift", "alt".
     #[napi]
     pub fn simulate_click(
@@ -421,15 +439,14 @@ impl TestGpuiRenderer {
 
     /// Simulate a single key down event through GPUI's input pipeline.
     /// Format: modifier-key string, e.g. "a", "enter", "cmd-s".
-    /// Unlike simulate_keystrokes, this dispatches ONLY a KeyDownEvent —
-    /// no automatic KeyUpEvent follows. Use with simulate_key_up for
+    /// Unlike `simulate_keystrokes`, this dispatches ONLY a `KeyDownEvent` —
+    /// no automatic `KeyUpEvent` follows. Use with `simulate_key_up` for
     /// fine-grained key event testing.
     #[napi]
     pub fn simulate_key_down(&self, keystroke: String, is_held: Option<bool>) -> Result<()> {
         with_test_state(|cx, window, _view| {
-            let parsed = gpui::Keystroke::parse(&keystroke).map_err(|e| {
-                Error::from_reason(format!("Invalid keystroke '{}': {}", keystroke, e))
-            })?;
+            let parsed = gpui::Keystroke::parse(&keystroke)
+                .map_err(|e| Error::from_reason(format!("Invalid keystroke '{keystroke}': {e}")))?;
 
             cx.simulate_event(
                 window,
@@ -446,13 +463,12 @@ impl TestGpuiRenderer {
 
     /// Simulate a single key up event through GPUI's input pipeline.
     /// Format: modifier-key string, e.g. "a", "enter", "cmd-s".
-    /// Pairs with simulate_key_down for fine-grained key event testing.
+    /// Pairs with `simulate_key_down` for fine-grained key event testing.
     #[napi]
     pub fn simulate_key_up(&self, keystroke: String) -> Result<()> {
         with_test_state(|cx, window, _view| {
-            let parsed = gpui::Keystroke::parse(&keystroke).map_err(|e| {
-                Error::from_reason(format!("Invalid keystroke '{}': {}", keystroke, e))
-            })?;
+            let parsed = gpui::Keystroke::parse(&keystroke)
+                .map_err(|e| Error::from_reason(format!("Invalid keystroke '{keystroke}': {e}")))?;
 
             cx.simulate_event(window, gpui::KeyUpEvent { keystroke: parsed });
 
@@ -461,7 +477,7 @@ impl TestGpuiRenderer {
     }
 
     /// Simulate a mouse move to the given coordinates.
-    /// pressed_button: optional mouse button held during move (0=left, 1=middle, 2=right).
+    /// `pressed_button`: optional mouse button held during move (0=left, 1=middle, 2=right).
     /// Used to simulate drag events.
     #[napi]
     pub fn simulate_mouse_move(
@@ -487,9 +503,9 @@ impl TestGpuiRenderer {
     }
 
     /// Focus an element by its numeric ID.
-    /// The element must have a FocusHandle (created by sync_focus_handles when
+    /// The element must have a `FocusHandle` (created by `sync_focus_handles` when
     /// the element has keyDown, keyUp, focus, or blur listeners).
-    /// Call flush() before this so the element tree and focus handles exist.
+    /// Call `flush()` before this so the element tree and focus handles exist.
     #[napi]
     pub fn focus_element(&self, id: f64) -> Result<()> {
         let id = to_element_id(id)?;
@@ -558,7 +574,7 @@ impl TestGpuiRenderer {
     }
 
     /// Simulate a scroll wheel event at the given position.
-    /// delta_x and delta_y are in pixels (negative = scroll up/left).
+    /// `delta_x` and `delta_y` are in pixels (negative = scroll up/left).
     #[napi]
     pub fn simulate_scroll_wheel(
         &self,
@@ -662,7 +678,7 @@ impl TestGpuiRenderer {
 
     /// Set the scroll offset of a scrollable element.
     /// x and y are negative pixel values (scroll down = more negative y).
-    /// Call flush() after to apply the offset and re-render.
+    /// Call `flush()` after to apply the offset and re-render.
     #[napi]
     pub fn scroll_to(&self, element_id: f64, x: f64, y: f64) -> Result<()> {
         let id = to_element_id(element_id)?;
@@ -684,7 +700,7 @@ impl TestGpuiRenderer {
     }
 
     /// Scroll a child into view by its index in the children list.
-    /// Call flush() after to apply and re-render.
+    /// Call `flush()` after to apply and re-render.
     #[napi]
     pub fn scroll_to_item(
         &self,
@@ -840,12 +856,12 @@ impl TestGpuiRenderer {
             // Capture via the platform renderer's render_to_image implementation.
             let image = cx
                 .capture_screenshot(window)
-                .map_err(|e| Error::from_reason(format!("Screenshot capture failed: {}", e)))?;
+                .map_err(|e| Error::from_reason(format!("Screenshot capture failed: {e}")))?;
 
             // Save as PNG (format inferred from file extension).
             image
                 .save(&path)
-                .map_err(|e| Error::from_reason(format!("Failed to save screenshot: {}", e)))?;
+                .map_err(|e| Error::from_reason(format!("Failed to save screenshot: {e}")))?;
 
             Ok(())
         })
@@ -898,8 +914,7 @@ impl TestGpuiRenderer {
         Ok(tree
             .elements
             .get(&id)
-            .map(|e| e.events.contains(&event_type))
-            .unwrap_or(false))
+            .is_some_and(|e| e.events.contains(&event_type)))
     }
 
     /// Get the text content of an element.
@@ -919,17 +934,44 @@ impl TestGpuiRenderer {
         let tree = self.tree.lock();
         let json = tree.to_json(&std::collections::HashMap::new());
         serde_json::to_string_pretty(&json)
-            .map_err(|e| Error::from_reason(format!("JSON serialization failed: {}", e)))
+            .map_err(|e| Error::from_reason(format!("JSON serialization failed: {e}")))
     }
 
     /// Tree JSON with last-paint bounds. Used by the automation locators.
+    /// GPUI accessibility tree from the last painted frame.
+    #[napi(js_name = "advanceTime")]
+    pub fn advance_time(&self, milliseconds: f64) -> Result<()> {
+        let duration =
+            std::time::Duration::try_from_secs_f64(milliseconds / 1000.0).map_err(|_| {
+                Error::from_reason("advanceTime requires a finite non-negative duration")
+            })?;
+        with_test_state(|cx, _window, _view| {
+            cx.advance_clock(duration);
+            cx.run_until_parked();
+            Ok(())
+        })
+    }
+
+    #[napi(js_name = "getA11yTree")]
+    pub fn get_a11y_tree(&self) -> Result<String> {
+        self.flush()?;
+        with_test_state(|cx, window, _view| {
+            cx.update_window(window, |_, window, _| {
+                window
+                    .debug_a11y_tree_json()
+                    .unwrap_or_else(|| "{}".to_owned())
+            })
+            .map_err(|error| Error::from_reason(error.to_string()))
+        })
+    }
+
     #[napi]
     pub fn get_automation_tree(&self) -> Result<String> {
         self.flush()?;
         let tree = self.tree.lock();
         let json = tree.to_automation_json(&crate::automation::all_bounds());
         serde_json::to_string(&json)
-            .map_err(|e| Error::from_reason(format!("JSON serialization failed: {}", e)))
+            .map_err(|e| Error::from_reason(format!("JSON serialization failed: {e}")))
     }
 
     /// Last painted bounds for an element, or null if it was not painted.
@@ -1028,8 +1070,8 @@ impl TestGpuiRenderer {
                 .update_window(window, |_, window, _| window.viewport_size())
                 .map_err(|error| Error::from_reason(error.to_string()))?;
             Ok(crate::renderer::WindowSize {
-                width: f32::from(size.width) as f64,
-                height: f32::from(size.height) as f64,
+                width: f64::from(f32::from(size.width)),
+                height: f64::from(f32::from(size.height)),
             })
         })
     }

--- a/crates/gpui-core/src/text/paint.rs
+++ b/crates/gpui-core/src/text/paint.rs
@@ -1,8 +1,11 @@
 //! The gpui half of text selection: the per-frame registry, the wash geometry,
 //! and the window-level mouse and key listeners.
 //!
-//! Ported from Comet (<https://github.com/zeronsh/comet>), MIT.
-//! Original: the selection sections of `crates/ui/src/markdown/render.rs`.
+//! Ported from Comet, MIT.
+//! Upstream: <https://github.com/zeronsh/comet/blob/main/crates/ui/src/markdown/render.rs>
+//! Reviewed fixes:
+//! - <https://github.com/zeronsh/comet/commit/f6911c311dc654734d31bc3097a84fb73659939f>
+//! - <https://github.com/zeronsh/comet/commit/3536a3702ca405fec1321e95f54e280240c5d38f>
 //!
 //! Why the registry is rebuilt during **paint** rather than during build:
 //! paint order is the only place where document order is guaranteed, because a
@@ -22,16 +25,14 @@ use gpui::{
 
 use super::selection::{self, SelectionState};
 
-/// Shared selection state. `GpuiView` and `GpuiRenderer` both hold clones, and
+/// Shared selection state. `GpuiView` and `GpuixRenderer` both hold clones, and
 /// so does every paint closure.
 ///
-/// `Arc<Mutex<..>>` rather than `Rc<RefCell<..>>`: napi requires `GpuiRenderer`
+/// `Arc<Mutex<..>>` rather than `Rc<RefCell<..>>`: napi requires `GpuixRenderer`
 /// to be `Send`, and the renderer needs a handle so `getSelectedText()` works
 /// without an App context. All real access is single-threaded, so the mutex is
 /// always uncontended.
 pub type SharedSelection = Arc<Mutex<SelectionState>>;
-pub type LayoutWash = Box<dyn Fn(&TextLayout, &mut Window)>;
-pub type LinkCallback = Arc<dyn Fn(&str)>;
 
 /// One painted text element, registered per frame in document order.
 struct RegEntry {
@@ -88,7 +89,11 @@ thread_local! {
 /// frame's copy and mouse-down listeners. Paint it FIRST in the root, before
 /// any text, so each frame holds exactly that frame's visible text elements
 /// in paint order.
-pub fn selection_frame_reset(selection: SharedSelection) -> impl IntoElement {
+pub fn selection_frame_reset(
+    selection: SharedSelection,
+    on_drag_move: impl Fn(gpui::Point<gpui::Pixels>, &mut gpui::App) + 'static,
+    on_drag_end: impl Fn(&mut gpui::App) + 'static,
+) -> impl IntoElement {
     canvas(
         |_, _, _| (),
         move |_, (), window, _| {
@@ -99,7 +104,7 @@ pub fn selection_frame_reset(selection: SharedSelection) -> impl IntoElement {
             super::search::ordinal_frame_reset();
             register_copy_listener(window, &selection);
             register_down_listener(window, &selection);
-            register_drag_listeners(window, &selection);
+            register_drag_listeners(window, &selection, on_drag_move, on_drag_end);
         },
     )
     .absolute()
@@ -191,6 +196,9 @@ pub enum HighlightSource {
     Native(Arc<super::search::HighlightContext>),
 }
 
+pub type LayoutWash = Box<dyn Fn(&TextLayout, &mut Window)>;
+pub type LinkCallback = Arc<dyn Fn(&str)>;
+
 pub struct SelectableText {
     /// Element that owns the run, and the run's index within it. The selection
     /// key is derived from these, so nothing has to parse it back apart.
@@ -248,8 +256,7 @@ impl SelectableText {
 }
 
 /// A selectable text element: `StyledText` with a canvas underlay that paints
-/// the selection wash, registers into the frame registry, and installs the
-/// mouse listeners.
+/// the selection wash and registers into the frame registry.
 pub fn selectable_text(opts: SelectableText) -> gpui::AnyElement {
     let SelectableText {
         element_id,
@@ -443,7 +450,7 @@ fn register_link_listener(
 /// still run into the gutter or past the last line.
 ///
 /// Comet compares Y only, because its transcript is a single column where two
-/// texts never share a vertical band. gpui-vue lays out arbitrary Vue trees: a
+/// texts never share a vertical band. GPUIX lays out arbitrary React trees: a
 /// Y-only match picks the leftmost text in a flex row no matter where the
 /// pointer actually is.
 fn registry_point(position: gpui::Point<gpui::Pixels>) -> Option<(usize, usize)> {
@@ -503,20 +510,10 @@ fn registry_point_on_line(position: gpui::Point<gpui::Pixels>) -> Option<(usize,
     })
 }
 
-/// Resolve anchor + head into document-ordered spans over the frame's registry.
-/// True when the selection changed.
-fn resolve_drag(
-    selection: &SharedSelection,
-    anchor_key: &str,
-    anchor_ix: usize,
-    head: (usize, usize),
-) -> bool {
+/// Resolve the drag head against the frame's registry.
+fn resolve_drag(selection: &SharedSelection, head: (usize, usize)) -> bool {
     REGISTRY.with(|r| {
         let reg = r.borrow();
-        let Some(anchor_ei) = reg.iter().position(|e| e.key.as_ref() == anchor_key) else {
-            // Anchor scrolled out of this frame — keep the spans we have.
-            return false;
-        };
         let elements: Vec<selection::RegisteredText> = reg
             .iter()
             .map(|e| selection::RegisteredText {
@@ -525,9 +522,19 @@ fn resolve_drag(
                 group: e.group,
             })
             .collect();
-        let spans = selection::resolve_spans(&elements, (anchor_ei, anchor_ix), head);
-        selection.lock().update_spans(spans)
+        selection.lock().update_drag(&elements, head)
     })
+}
+
+/// Continue an active drag at a window position.
+pub(crate) fn update_drag_at(
+    selection: &SharedSelection,
+    position: gpui::Point<gpui::Pixels>,
+) -> bool {
+    let Some(head) = registry_point(position) else {
+        return false;
+    };
+    resolve_drag(selection, head)
 }
 
 /// One window-level mouse-down for the whole frame.
@@ -591,50 +598,48 @@ fn register_down_listener(window: &mut Window, selection: &SharedSelection) {
     });
 }
 
-/// Register this frame's single pair of window-level drag listeners.
+/// One window-level move and up listener for the frame.
 ///
-/// Window-level, not element-level, so a drag keeps tracking after the mouse
-/// leaves the element's bounds. The active key lives in `SelectionState`, so
-/// the listener count is constant regardless of how many text runs are visible.
-fn register_drag_listeners(window: &mut Window, selection: &SharedSelection) {
-    use gpui::{DispatchPhase, MouseMoveEvent, MouseUpEvent};
+/// These are independent of the anchor run, so virtualization cannot remove
+/// the listener that owns the active drag. The reset canvas is the first root
+/// child, so gpui's reverse bubble order runs these last. Do not stop
+/// propagation on mouse-up elsewhere, or a drag and its edge-scroll timer
+/// stay armed.
+fn register_drag_listeners(
+    window: &mut Window,
+    selection: &SharedSelection,
+    on_drag_move: impl Fn(gpui::Point<gpui::Pixels>, &mut gpui::App) + 'static,
+    on_drag_end: impl Fn(&mut gpui::App) + 'static,
+) {
+    use gpui::{DispatchPhase, MouseButton, MouseMoveEvent, MouseUpEvent};
 
-    {
-        let selection = selection.clone();
-        window.on_mouse_event(move |e: &MouseMoveEvent, phase, window, _cx| {
-            if phase != DispatchPhase::Bubble || !e.dragging() {
-                return;
-            }
-            let (promoted, active_drag) = {
-                let mut state = selection.lock();
-                let promoted = state.promote_pending();
-                (promoted, state.active_drag())
-            };
-            if promoted {
-                window.blur();
-            }
-            let Some((key, anchor_ix)) = active_drag else {
-                return;
-            };
-            let Some(head) = registry_point(e.position) else {
-                return;
-            };
-            if resolve_drag(&selection, &key, anchor_ix, head) {
-                window.refresh();
-            }
-        });
-    }
-    {
-        let selection = selection.clone();
-        window.on_mouse_event(move |_: &MouseUpEvent, phase, _window, _cx| {
-            if phase != DispatchPhase::Bubble {
-                return;
-            }
-            let mut sel = selection.lock();
-            sel.cancel_pending();
-            sel.end_active_drag();
-        });
-    }
+    let move_selection = selection.clone();
+    window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
+        if phase != DispatchPhase::Bubble || !event.dragging() {
+            return;
+        }
+        if move_selection.lock().promote_pending() {
+            window.blur();
+        }
+        if update_drag_at(&move_selection, event.position) {
+            window.refresh();
+        }
+        if move_selection.lock().is_dragging() {
+            on_drag_move(event.position, cx);
+        }
+    });
+
+    let up_selection = selection.clone();
+    window.on_mouse_event(move |event: &MouseUpEvent, phase, _window, cx| {
+        if phase != DispatchPhase::Bubble || event.button != MouseButton::Left {
+            return;
+        }
+        let mut selection = up_selection.lock();
+        selection.cancel_pending();
+        selection.end_active_drag();
+        drop(selection);
+        on_drag_end(cx);
+    });
 }
 
 fn register_copy_listener(window: &mut Window, selection: &SharedSelection) {
@@ -671,35 +676,56 @@ pub fn range_rects(
     pad_x: f32,
     inset_y: f32,
 ) -> Vec<Bounds<gpui::Pixels>> {
+    range_rects_with_positions(
+        layout.bounds(),
+        layout.line_height(),
+        range,
+        pad_x,
+        inset_y,
+        |index| layout.position_for_index(index),
+    )
+}
+
+fn range_rects_with_positions(
+    bounds: Bounds<gpui::Pixels>,
+    line_height: gpui::Pixels,
+    range: &Range<usize>,
+    pad_x: f32,
+    inset_y: f32,
+    position_for_index: impl Fn(usize) -> Option<gpui::Point<gpui::Pixels>>,
+) -> Vec<Bounds<gpui::Pixels>> {
     let mut rects = Vec::new();
-    let line_height = layout.line_height();
     let mut cur = range.start;
     // Walk the range one visual row at a time: binary search for the furthest
     // index that still sits on the current row.
     let mut guard = 0;
     while cur < range.end && guard < 256 {
         guard += 1;
-        let Some(p1) = layout.position_for_index(cur) else {
+        let Some(mut p1) = position_for_index(cur) else {
             break;
         };
-        // `seg_end` closes the wash on this row; `next` is the first index on the
-        // following row. They differ because a row-end index's position still
-        // reports the earlier row, and we need strict progress.
-        let (seg_end, next) = match layout.position_for_index(range.end) {
+        if let Some(after) = position_for_index(cur.saturating_add(1))
+            && after.y > p1.y
+        {
+            p1 = point(bounds.left(), after.y);
+        }
+        // A soft-wrap boundary closes one row with upstream affinity and starts
+        // the next row with the downstream correction above.
+        let (seg_end, next) = match position_for_index(range.end) {
             Some(pe) if pe.y == p1.y => (range.end, range.end),
             _ => {
                 let (mut lo, mut hi) = (cur, range.end);
                 while hi - lo > 1 {
                     let mid = lo + (hi - lo) / 2;
-                    match layout.position_for_index(mid) {
+                    match position_for_index(mid) {
                         Some(pm) if pm.y == p1.y => lo = mid,
                         _ => hi = mid,
                     }
                 }
-                (lo, hi)
+                (lo, lo)
             }
         };
-        if let Some(p2) = layout.position_for_index(seg_end)
+        if let Some(p2) = position_for_index(seg_end)
             && p2.x > p1.x
         {
             rects.push(Bounds::new(
@@ -716,4 +742,57 @@ pub fn range_rects(
         cur = next;
     }
     rects
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Model GPUI's upstream affinity at a soft-wrap boundary: byte 5 is
+    /// reported at the end of row 0, while byte 6 is after the first glyph on
+    /// row 1.
+    fn wrapped_position(ix: usize) -> Option<gpui::Point<gpui::Pixels>> {
+        (ix <= 9).then(|| {
+            if ix <= 5 {
+                point(
+                    px(f32::from(u8::try_from(ix).expect("test index fits u8")) * 10.0),
+                    px(0.0),
+                )
+            } else {
+                point(
+                    px(f32::from(u8::try_from(ix - 5).expect("test index fits u8")) * 10.0),
+                    px(22.0),
+                )
+            }
+        })
+    }
+
+    fn wrapped_range_rects(range: Range<usize>) -> Vec<Bounds<gpui::Pixels>> {
+        range_rects_with_positions(
+            Bounds::new(point(px(0.0), px(0.0)), size(px(50.0), px(44.0))),
+            px(22.0),
+            &range,
+            0.0,
+            0.0,
+            wrapped_position,
+        )
+    }
+
+    #[test]
+    fn range_starting_at_soft_wrap_includes_first_glyph() {
+        let rects = wrapped_range_rects(5..9);
+        assert_eq!(rects.len(), 1);
+        assert_eq!(rects[0].origin, point(px(0.0), px(22.0)));
+        assert_eq!(rects[0].size, size(px(40.0), px(22.0)));
+    }
+
+    #[test]
+    fn range_crossing_soft_wrap_includes_first_continuation_glyph() {
+        let rects = wrapped_range_rects(2..9);
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0].origin, point(px(20.0), px(0.0)));
+        assert_eq!(rects[0].size, size(px(30.0), px(22.0)));
+        assert_eq!(rects[1].origin, point(px(0.0), px(22.0)));
+        assert_eq!(rects[1].size, size(px(40.0), px(22.0)));
+    }
 }

--- a/crates/gpui-core/src/text/selection.rs
+++ b/crates/gpui-core/src/text/selection.rs
@@ -1,7 +1,8 @@
 //! Cross-element text selection state.
 //!
-//! Ported from Comet (<https://github.com/zeronsh/comet>), MIT.
-//! Original: `crates/ui/src/markdown/selection.rs`.
+//! Ported from Comet, MIT.
+//! Upstream: <https://github.com/zeronsh/comet/blob/main/crates/ui/src/markdown/selection.rs>
+//! Reviewed fix: <https://github.com/zeronsh/comet/commit/3536a3702ca405fec1321e95f54e280240c5d38f>
 //!
 //! GPUI has no built-in selection for plain text. Zed's markdown selects
 //! continuously because its whole document is ONE element over one text model.
@@ -22,7 +23,6 @@
 //! selection.
 
 use std::ops::Range;
-
 use unicode_segmentation::UnicodeSegmentation;
 
 /// One element's slice of the selection, in document order.
@@ -64,6 +64,8 @@ pub struct SelectionState {
     /// Byte offset of the anchor within its element.
     anchor_ix: usize,
     dragging: bool,
+    /// Direction established while the anchor is still painted.
+    forward: Option<bool>,
     /// Resolved spans in document order. Empty while a click has not moved.
     spans: Vec<Span>,
     active: bool,
@@ -79,11 +81,13 @@ impl SelectionState {
         self.anchor_key = key.to_string();
         self.anchor_ix = ix;
         self.dragging = false;
+        self.forward = None;
         self.active = false;
         self.pending = true;
         self.spans.clear();
     }
 
+    /// Turn a pending press into a live drag. True when this call started it.
     pub fn promote_pending(&mut self) -> bool {
         if !self.pending {
             return false;
@@ -92,10 +96,6 @@ impl SelectionState {
         self.dragging = true;
         self.active = true;
         true
-    }
-
-    pub fn active_drag(&self) -> Option<(String, usize)> {
-        (self.active && self.dragging).then(|| (self.anchor_key.clone(), self.anchor_ix))
     }
 
     pub fn cancel_pending(&mut self) {
@@ -113,6 +113,7 @@ impl SelectionState {
         self.anchor_key = key.to_string();
         self.anchor_ix = range.start;
         self.dragging = true;
+        self.forward = None;
         self.active = true;
         self.pending = false;
         self.spans = vec![Span {
@@ -121,6 +122,37 @@ impl SelectionState {
             text: text.to_string(),
             group: None,
         }];
+    }
+
+    pub fn is_dragging(&self) -> bool {
+        self.active && self.dragging
+    }
+
+    /// Resolve a drag head against this frame's visible runs.
+    ///
+    /// Once virtualization removes the anchor, an overlapping selected run
+    /// joins the visible frame to the spans retained from earlier frames.
+    pub fn update_drag(&mut self, elements: &[RegisteredText], head: (usize, usize)) -> bool {
+        if !self.is_dragging() {
+            return false;
+        }
+        let spans = if let Some(anchor_element) = elements
+            .iter()
+            .position(|element| element.key == self.anchor_key)
+        {
+            let anchor = (anchor_element, self.anchor_ix);
+            self.forward = Some(anchor <= head);
+            resolve_spans(elements, anchor, head)
+        } else {
+            let Some(forward) = self.forward else {
+                return false;
+            };
+            let Some(spans) = extend_virtualized_drag(&self.spans, elements, head, forward) else {
+                return false;
+            };
+            spans
+        };
+        self.update_spans(spans)
     }
 
     /// Replace the resolved spans. Returns true when they changed.
@@ -132,22 +164,17 @@ impl SelectionState {
         true
     }
 
-    /// End the drag for `key`'s claim. Returns the joined text when non-empty.
-    pub fn end_drag(&mut self, key: &str) -> Option<String> {
-        if !self.active || self.anchor_key != key || !self.dragging {
+    /// End the active drag even when its anchor is no longer painted.
+    pub fn end_active_drag(&mut self) -> Option<String> {
+        if !self.is_dragging() {
             return None;
         }
         self.dragging = false;
-        if self.spans.iter().all(|s| s.range.is_empty()) {
+        if self.spans.iter().all(|span| span.range.is_empty()) {
             self.clear();
             return None;
         }
         Some(join_spans(&self.spans))
-    }
-
-    pub fn end_active_drag(&mut self) -> Option<String> {
-        let key = self.anchor_key.clone();
-        self.end_drag(&key)
     }
 
     pub fn clear(&mut self) {
@@ -175,6 +202,46 @@ impl SelectionState {
             return None;
         }
         Some(join_spans(&self.spans))
+    }
+}
+
+fn extend_virtualized_drag(
+    existing: &[Span],
+    elements: &[RegisteredText],
+    head: (usize, usize),
+    forward: bool,
+) -> Option<Vec<Span>> {
+    if forward {
+        let (element_index, span_index) =
+            elements
+                .iter()
+                .enumerate()
+                .find_map(|(element_index, element)| {
+                    existing
+                        .iter()
+                        .position(|span| span.key == element.key)
+                        .map(|span_index| (element_index, span_index))
+                })?;
+        let start = existing.get(span_index)?.range.start;
+        let mut merged = existing.get(..span_index)?.to_vec();
+        merged.extend(resolve_spans(elements, (element_index, start), head));
+        Some(merged)
+    } else {
+        let (element_index, span_index) =
+            elements
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(element_index, element)| {
+                    existing
+                        .iter()
+                        .position(|span| span.key == element.key)
+                        .map(|span_index| (element_index, span_index))
+                })?;
+        let end = existing.get(span_index)?.range.end;
+        let mut merged = resolve_spans(elements, head, (element_index, end));
+        merged.extend_from_slice(existing.get(span_index + 1..)?);
+        Some(merged)
     }
 }
 
@@ -224,7 +291,7 @@ fn clamp_boundary(text: &str, mut ix: usize) -> usize {
 /// nothing between runs of the same group.
 ///
 /// Without the group check, copying `<text>Hello {name}!</text>` yields
-/// `"Hello\nTommy\n!"`, because Vue split one line into three host nodes.
+/// `"Hello\nTommy\n!"`, because React split one line into three host nodes.
 fn join_spans(spans: &[Span]) -> String {
     let mut out = String::new();
     let mut previous: Option<Option<u64>> = None;
@@ -313,17 +380,114 @@ mod tests {
         let mut sel = SelectionState::default();
         sel.arm("p1", 6);
         assert!(sel.promote_pending());
-        assert_eq!(sel.active_drag(), Some(("p1".to_string(), 6)));
+        assert!(sel.is_dragging());
         let spans = resolve_spans(&elems(), (0, 6), (1, 6));
         assert!(sel.update_spans(spans.clone()));
         assert!(!sel.update_spans(spans));
         assert_eq!(sel.wash_range("p1"), Some(6..15));
         assert_eq!(sel.wash_range("p2"), Some(0..6));
         assert_eq!(sel.wash_range("p3"), None);
-        assert_eq!(sel.end_drag("p1").as_deref(), Some("paragraph\nsecond"));
+        assert_eq!(sel.end_active_drag().as_deref(), Some("paragraph\nsecond"));
         assert_eq!(sel.selected_text().as_deref(), Some("paragraph\nsecond"));
         sel.clear();
         assert_eq!(sel.selected_text(), None);
+    }
+
+    #[test]
+    fn drag_survives_forward_virtualization() {
+        let mut sel = SelectionState::default();
+        sel.arm("p1", 6);
+        assert!(sel.promote_pending());
+        assert!(sel.update_drag(&elems(), (2, 5)));
+        let shifted = [
+            reg("p2", "second", None),
+            reg("p3", "third one", None),
+            reg("p4", "fourth", None),
+        ];
+        assert!(sel.update_drag(&shifted, (2, 4)));
+        assert_eq!(
+            sel.selected_text().as_deref(),
+            Some("paragraph\nsecond\nthird one\nfour")
+        );
+        assert_eq!(
+            sel.end_active_drag().as_deref(),
+            Some("paragraph\nsecond\nthird one\nfour")
+        );
+        assert!(!sel.is_dragging());
+    }
+
+    #[test]
+    fn drag_survives_backward_virtualization() {
+        let mut sel = SelectionState::default();
+        sel.arm("p5", 4);
+        assert!(sel.promote_pending());
+        let first = [
+            reg("p3", "third", None),
+            reg("p4", "fourth", None),
+            reg("p5", "fifth", None),
+        ];
+        assert!(sel.update_drag(&first, (0, 2)));
+        let shifted = [
+            reg("p2", "second", None),
+            reg("p3", "third", None),
+            reg("p4", "fourth", None),
+        ];
+        assert!(sel.update_drag(&shifted, (0, 3)));
+        assert_eq!(
+            sel.selected_text().as_deref(),
+            Some("ond\nthird\nfourth\nfift")
+        );
+        assert_eq!(
+            sel.end_active_drag().as_deref(),
+            Some("ond\nthird\nfourth\nfift")
+        );
+    }
+
+    #[test]
+    fn virtualized_drag_requires_overlap() {
+        let mut sel = SelectionState::default();
+        sel.arm("p1", 6);
+        assert!(sel.promote_pending());
+        assert!(sel.update_drag(&elems(), (2, 5)));
+        let unrelated = [reg("p8", "eighth", None), reg("p9", "ninth", None)];
+        assert!(!sel.update_drag(&unrelated, (1, 3)));
+        assert_eq!(
+            sel.selected_text().as_deref(),
+            Some("paragraph\nsecond\nthird")
+        );
+    }
+
+    #[test]
+    fn virtualized_drag_waits_until_direction_is_known() {
+        let mut sel = SelectionState::default();
+        sel.arm("p1", 6);
+        assert!(sel.promote_pending());
+        let shifted = [reg("p2", "second", None), reg("p3", "third", None)];
+        assert!(!sel.update_drag(&shifted, (1, 3)));
+        assert_eq!(sel.selected_text(), None);
+    }
+
+    #[test]
+    fn virtualized_copy_preserves_grouped_and_ungrouped_runs() {
+        let mut sel = SelectionState::default();
+        sel.arm("2:0", 0);
+        assert!(sel.promote_pending());
+        let first = [
+            reg("2:0", "Hello ", Some(1)),
+            reg("3:0", "Tommy", Some(1)),
+            reg("7:0", "let a = 1;", None),
+        ];
+        assert!(sel.update_drag(&first, (2, 10)));
+        let shifted = [
+            reg("3:0", "Tommy", Some(1)),
+            reg("7:0", "let a = 1;", None),
+            reg("7:1", "let b = 2;", None),
+        ];
+        assert!(sel.update_drag(&shifted, (2, 10)));
+        assert_eq!(
+            sel.selected_text().as_deref(),
+            Some("Hello Tommy\nlet a = 1;\nlet b = 2;")
+        );
     }
 
     #[test]
@@ -331,7 +495,7 @@ mod tests {
         let mut sel = SelectionState::default();
         sel.arm("p1", 3);
         assert!(sel.promote_pending());
-        assert_eq!(sel.end_drag("p1"), None);
+        assert_eq!(sel.end_active_drag(), None);
         assert_eq!(sel.selected_text(), None);
     }
 
@@ -341,22 +505,22 @@ mod tests {
         sel.arm("p1", 3);
         assert!(sel.is_pending());
         assert!(!sel.is_active());
-        assert_eq!(sel.active_drag(), None);
+        assert!(!sel.is_dragging());
         sel.cancel_pending();
         assert!(!sel.is_pending());
         assert_eq!(sel.selected_text(), None);
     }
 
     #[test]
-    fn pending_press_promotes_only_once() {
+    fn pending_press_promotes_on_drag() {
         let mut sel = SelectionState::default();
         sel.arm("p1", 6);
         assert!(sel.promote_pending());
         assert!(!sel.promote_pending());
-        assert_eq!(sel.active_drag(), Some(("p1".to_string(), 6)));
+        assert!(sel.is_dragging());
         let spans = resolve_spans(&elems(), (0, 6), (0, 15));
         assert!(sel.update_spans(spans));
-        assert_eq!(sel.end_drag("p1").as_deref(), Some("paragraph"));
+        assert_eq!(sel.end_active_drag().as_deref(), Some("paragraph"));
     }
 
     #[test]
@@ -364,7 +528,7 @@ mod tests {
         let mut sel = SelectionState::default();
         sel.begin_with_span("p1", "hello world", 6..11);
         assert_eq!(sel.wash_range("p1"), Some(6..11));
-        assert_eq!(sel.end_drag("p1").as_deref(), Some("world"));
+        assert_eq!(sel.end_active_drag().as_deref(), Some("world"));
     }
 
     #[test]
@@ -378,8 +542,6 @@ mod tests {
         assert_eq!(word_range(t, 3), 0..3);
         let u = "héllo wörld";
         assert_eq!(&u[word_range(u, 2)], "héllo");
-        let combining = "cafe\u{301} noir";
-        assert_eq!(&combining[word_range(combining, 2)], "cafe\u{301}");
     }
 
     /// A stale index past a shrunk element's text must clamp, not panic.
@@ -389,7 +551,7 @@ mod tests {
         assert_eq!(&spans[0].text[spans[0].range.clone()], "hé");
     }
 
-    /// Vue splits one line into three host nodes. Copy must not insert
+    /// React splits one line into three host nodes. Copy must not insert
     /// newlines between them.
     #[test]
     fn copy_joins_one_group_without_newlines() {

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,0 +1,119 @@
+# GPUix synchronization record
+
+Reviewed on 2026-09-08 against GPUix `main` at
+[`6b4be86952aa89cfe61bb573740aea33fef5c5c4`](https://github.com/remorses/gpuix/commit/6b4be86952aa89cfe61bb573740aea33fef5c5c4).
+This is a review checkpoint, not a claim that this repository is an exact copy
+of that commit.
+
+## Where this repository started
+
+The original imported source is recorded in `THIRD_PARTY_NOTICES.md` as
+`b8bbff4ef0dc00dc24c3d3f3ca47818e1be15c69` (2026-08-23). Local commit
+`ffbc88a5a1f8ca0776850f6ae1c7c36750419153` subsequently incorporated selected
+upstream behavior and refactored the engine. It did not record a new GPUix
+checkpoint. Before this review, the GPUI dependency was pinned to
+`8b94defe56992b3ca4ffd4853ace741d8168111a`.
+
+Consequently, commit dates alone cannot determine which fixes are present.
+This review compared the implementations and commit diffs after the original
+import, including the native engine and framework-facing lifecycle changes.
+
+## Changes incorporated in this synchronization
+
+| GPUix commits        | Change and local adaptation                                                                                                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fb75c1c`, `1cd46cd` | Selection survives virtualized anchor removal; frame-owned drag listeners, edge autoscroll with end detection, soft-wrap wash geometry, input word selection and drag scrolling, and coalesced undo. Preserve local Unicode word boundaries and both entry and byte limits on undo/redo history.                                |
+| `09e0cae`            | Structured two-stop linear gradients with sRGB/Oklab interpolation. Preserve the local parsed-style cache and share background resolution with occlusion and anchored fills.                                                                                                                                                    |
+| `aacb070`            | Set Windows DPI awareness on the GPUI UI thread before native windows are created. Keep the existing event-driven window-close lifecycle instead of adopting upstream's polling loop.                                                                                                                                           |
+| `b20e98a`, `0bb3c94` | Retain decoded raster data URLs and HTTP(S) URI sources; install GPUI's HTTP client on desktop; preserve definite image dimensions while loading. Keep the local SVG adapter and its decoding behavior.                                                                                                                         |
+| `10e1bb0`, `3bb1ac6` | Remove process-wide Tab traversal; expose `focusNext`, `focusPrevious`, and renderer-level key callbacks with per-mount event identities on native and WebAssembly. Browser Tab still keeps keyboard focus inside GPUI.                                                                                                         |
+| `1c4c67b`            | Persist renderer ownership, event registries, and monotonically increasing node IDs across module reloads. Keep Vue reconciliation and state machinery. Reject stale queued events after a remount.                                                                                                                             |
+| `e948b20`            | Dispatch live mouse automation without leasing the root view on macOS, threaded hosts, and WebAssembly.                                                                                                                                                                                                                         |
+| `bf98e07`            | Deliver primary clicks from mouse-up on host and custom surfaces; preserve mouse-up-before-click order and register the matching accessibility action.                                                                                                                                                                          |
+| `9b1def2`, `5700c96` | Pick up nonblocking AppKit pumping through the GPUI revision update; retain the existing JavaScript frame loop.                                                                                                                                                                                                                 |
+| `2487521`, `5f066f3` | Keep pumping after frame exceptions, contain native/browser event-handler exceptions, and display a per-window Vue error stack. Component errors use Vue's error boundary. Global process exception/rejection interception is intentionally not installed: applications retain ownership of their process-level failure policy. |
+| `95757bb`            | Underline, line-through, and explicit removal of text decoration through the shared style/painter.                                                                                                                                                                                                                              |
+| `ff3c1a2`            | Plain textarea Enter inserts a newline; an active submit listener makes Enter submit. Shift+Enter stays a newline. Listener changes update the key context.                                                                                                                                                                     |
+| `4bea250`, `fa61d80` | Font-sized caret and matching IME bounds; vertically centered single-line inputs and clipping to rounded corners.                                                                                                                                                                                                               |
+| `8138d4c`, `9e0db51` | Native accessibility roles and ARIA properties, text/input/image defaults, accessible click actions, and coverage for virtual lists, anchored surfaces, and empty images. Test API exposes the actual painted accessibility tree.                                                                                               |
+
+The GPUI dependency now matches GPUix's reviewed submodule revision:
+`1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9`. This supplies the accessibility hooks
+for list/image/SVG elements and activation in GPU-backed tests.
+
+## Already present or intentionally different
+
+- Atomic validated batches, content-interned styles and reclamation, stable
+  native identities, removed text-node cleanup, one live Vue root per renderer,
+  custom-element event wiring/reset, and shared text selection/highlight paths
+  were already present. Do not replace the local split renderer with GPUix's
+  monolithic renderer to reproduce these changes.
+- The existing port already has browser rendering, pointer capture, native
+  clipboard/input plumbing, safe-area insets, debug overlays, variable-height
+  list estimates/anchors, virtualized highlight offsets, native automation,
+  Syntect's native/Wasm backends, bare code surfaces, and theme-driven metrics.
+- Window lifecycle and resize notifications are event-driven locally. GPUix's
+  polling fixes are covered by the existing lifecycle implementation and tests.
+- `5937978` exports a throwing Linux test-renderer stub upstream. Locally the
+  GPU test renderer remains explicitly available only on macOS/Windows, and
+  `hasNativeTestRenderer` checks the export. No throwing stub is needed.
+- React reconciliation, hooks, Fast Refresh, React-specific test helpers,
+  starter templates, app examples, release/publish metadata, screenshots, and
+  website tooling are not copied into the Vue adapter.
+- `e082247`, `2d6e599`, and `6b4be86` describe future iOS/Hermes packaging. They
+  are plans/documentation, not a completed mobile renderer to port. This
+  repository does not claim iOS or Hermes support.
+- Dependency-only lockfile bumps and contributor preferences (such as leaving
+  development windows running) are not renderer fixes.
+
+## Application-facing changes
+
+Window key handlers belong to each `render(App, options)` or `createWindow`
+call. Applications that want Tab traversal must opt in; the runtime no longer
+installs process-wide Tab bindings:
+
+```ts
+const root = render(App, {
+  onKeyDown(event) {
+    if (event.key !== "tab") return
+    if (event.modifiers?.shift) root.renderer.focusPrevious?.()
+    else root.renderer.focusNext?.()
+  },
+})
+```
+
+Use `role` and kebab-case `aria-*` host props for accessible names, descriptions,
+values, selection and expansion. Images accept `alt`. Text and editable inputs
+receive native default roles. Underline and strike-through use
+`style.textDecoration` (`"underline"`, `"line-through"`, or `"none"`).
+
+`style.background` still accepts a color string. A gradient uses
+`{ type: "linear-gradient", angle: 90, stops: [{ color: "red", position: 0 },
+{ color: "blue", position: 1 }], colorSpace: "srgb" }`; `"oklab"` is also
+supported. Exactly two stops are required.
+
+Textarea Enter now inserts a newline unless an `onSubmit` listener is present.
+Shift+Enter always inserts a newline. Callback and component exceptions display
+an error stack in the affected window; a remount resets that display.
+
+## Verification and the next review
+
+Rust tests cover selection continuation, wrap geometry, input key contexts,
+undo coalescing/budgets, URI parsing, gradients, and accessibility role mapping.
+Vue tests cover prop forwarding/removal, stale events, key-listener lifetime,
+frame-error recovery, and the error display. The native smoke command includes
+GPU-backed accessibility, click, textarea, and pixel-change checks on supported
+platforms. WebAssembly must build with the same APIs and retain the
+single-threaded Pages deployment.
+
+Validated locally on macOS: the full `bun run check`, 39 JavaScript tests,
+244 Rust tests, native binding generation, native load/close/reopen and GPU
+smoke tests, and the Pages/WebAssembly build pass. Built HTML asset references
+resolve under `/gpui-native/`. A separate Bun module-reload check confirms
+shared event registrations survive reload and removed registrations stay removed.
+Windows and Linux builds are delegated to the PR's CI matrix.
+
+For the next review, compare GPUix commits after the checkpoint above, then
+check code before porting. Update this document with the reviewed full SHA,
+the GPUI pin, incorporated changes, intentional differences, and validation
+results. Keep the original provenance in `THIRD_PARTY_NOTICES.md`.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "oxlint --vue-plugin --fix packages/vue/src packages/vue/test examples web scripts vite.examples.config.mts vite.pages.config.mts",
     "setup:wasm": "bun run scripts/install-wasm-bindgen.mts",
     "test": "bun --filter @gpui-native/vue test && cargo test --workspace --all-features",
-    "test:native": "bun run scripts/native-smoke.mts",
+    "test:native": "bun run scripts/native-smoke.mts && bun packages/vue/test/native-upstream.mts",
     "typecheck": "bun --filter @gpui-native/vue typecheck && bun --filter '@gpui-vue/example-*' typecheck && bun packages/vue/node_modules/typescript/bin/tsc --noEmit -p web/tsconfig.json"
   },
   "devDependencies": {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -93,6 +93,9 @@ export declare class GpuiRenderer {
   activateWindow(): void
   setWindowTitle(title: string): void
   focusElement(elementId: number): void
+  focusNext(): void
+  focusPrevious(): void
+  setWindowKeyEvents(keyDown: boolean, keyUp: boolean, eventId: number): void
   blur(): void
   /** The current text selection joined in document order, or null. */
   getSelectedText(): string | null
@@ -165,19 +168,21 @@ export declare class GpuiRenderer {
 }
 
 /**
- * GPU-backed GPUI test renderer. Uses VisualTestAppContext with the native
- * Metal or DirectX renderer and TestDispatcher for deterministic scheduling.
- * Same GpuiView and rendering pipeline as production.
+ * GPU-backed GPUI test renderer. Uses `VisualTestAppContext` with the native
+ * Metal or DirectX renderer and `TestDispatcher` for deterministic scheduling.
+ * Same `GpuiView` and rendering pipeline as production.
  *
  * Usage from JS:
- *   const r = new TestGpuiRenderer()
- *   r.createElement(1, "div")
- *   r.setRoot(1)
- *   r.commitMutations()
- *   r.flush()                  // triggers GpuiView::render() on the GPU
- *   r.simulateClick(50, 50)    // dispatches through GPUI hit testing
- *   const events = r.drainEvents()
- *   r.captureScreenshot("/tmp/test.png")  // saves rendered UI as PNG
+ * ```javascript
+ * const r = new TestGpuiRenderer()
+ * r.createElement(1, "div")
+ * r.setRoot(1)
+ * r.commitMutations()
+ * r.flush()                  // paints the retained view on the GPU
+ * r.simulateClick(50, 50)    // dispatches through GPUI hit testing
+ * const events = r.drainEvents()
+ * r.captureScreenshot("/tmp/test.png")
+ * ```
  */
 export declare class TestGpuiRenderer {
   constructor(width?: number | undefined | null, height?: number | undefined | null)
@@ -201,27 +206,27 @@ export declare class TestGpuiRenderer {
   getCustomProp(id: number, key: string): string | null
   /**
    * Signal that a batch of mutations is complete.
-   * In tests, this is a no-op — flush() handles the actual re-render.
+   * In tests, this is a no-op — `flush()` handles the actual re-render.
    */
   commitMutations(): void
   /**
    * Apply a batch of mutations in a single FFI call.
-   * Same format as GpuiRenderer::apply_batch (string op names).
+   * Same format as `GpuiRenderer::apply_batch` (string op names).
    * Returns accumulated destroyed IDs from all destroyElement ops.
    */
   applyBatch(json: string): Array<number>
   /**
    * Notify the view entity and run GPUI until parked.
-   * This triggers GpuiView::render() → build_element() → GPUI layout.
+   * This triggers `GpuiView::render()` → `build_element()` → GPUI layout.
    * Must be called after mutations and before simulating events (GPUI's
    * hit testing requires elements to be laid out).
    */
   flush(): void
   /**
    * Simulate a click at the given window coordinates.
-   * Dispatches MouseDown + MouseUp through GPUI's input pipeline,
+   * Dispatches `MouseDown` + `MouseUp` through GPUI's input pipeline,
    * which triggers the same event handlers as production.
-   * IMPORTANT: Call flush() before this — hit testing requires laid-out elements.
+   * IMPORTANT: Call `flush()` before this — hit testing requires laid-out elements.
    * `modifiers` uses the `press()` syntax: "cmd", "cmd-shift", "alt".
    */
   simulateClick(x: number, y: number, button?: number | undefined | null, modifiers?: string | undefined | null): void
@@ -234,28 +239,28 @@ export declare class TestGpuiRenderer {
   /**
    * Simulate a single key down event through GPUI's input pipeline.
    * Format: modifier-key string, e.g. "a", "enter", "cmd-s".
-   * Unlike simulate_keystrokes, this dispatches ONLY a KeyDownEvent —
-   * no automatic KeyUpEvent follows. Use with simulate_key_up for
+   * Unlike `simulate_keystrokes`, this dispatches ONLY a `KeyDownEvent` —
+   * no automatic `KeyUpEvent` follows. Use with `simulate_key_up` for
    * fine-grained key event testing.
    */
   simulateKeyDown(keystroke: string, isHeld?: boolean | undefined | null): void
   /**
    * Simulate a single key up event through GPUI's input pipeline.
    * Format: modifier-key string, e.g. "a", "enter", "cmd-s".
-   * Pairs with simulate_key_down for fine-grained key event testing.
+   * Pairs with `simulate_key_down` for fine-grained key event testing.
    */
   simulateKeyUp(keystroke: string): void
   /**
    * Simulate a mouse move to the given coordinates.
-   * pressed_button: optional mouse button held during move (0=left, 1=middle, 2=right).
+   * `pressed_button`: optional mouse button held during move (0=left, 1=middle, 2=right).
    * Used to simulate drag events.
    */
   simulateMouseMove(x: number, y: number, pressedButton?: number | undefined | null, modifiers?: string | undefined | null): void
   /**
    * Focus an element by its numeric ID.
-   * The element must have a FocusHandle (created by sync_focus_handles when
+   * The element must have a `FocusHandle` (created by `sync_focus_handles` when
    * the element has keyDown, keyUp, focus, or blur listeners).
-   * Call flush() before this so the element tree and focus handles exist.
+   * Call `flush()` before this so the element tree and focus handles exist.
    */
   focusElement(id: number): void
   /**
@@ -270,7 +275,7 @@ export declare class TestGpuiRenderer {
   simulateMouseUp(x: number, y: number, button?: number | undefined | null, modifiers?: string | undefined | null): void
   /**
    * Simulate a scroll wheel event at the given position.
-   * delta_x and delta_y are in pixels (negative = scroll up/left).
+   * `delta_x` and `delta_y` are in pixels (negative = scroll up/left).
    */
   simulateScrollWheel(x: number, y: number, deltaX: number, deltaY: number, modifiers?: string | undefined | null): void
   /** The current text selection joined in document order, or null. */
@@ -313,12 +318,12 @@ export declare class TestGpuiRenderer {
   /**
    * Set the scroll offset of a scrollable element.
    * x and y are negative pixel values (scroll down = more negative y).
-   * Call flush() after to apply the offset and re-render.
+   * Call `flush()` after to apply the offset and re-render.
    */
   scrollTo(elementId: number, x: number, y: number): void
   /**
    * Scroll a child into view by its index in the children list.
-   * Call flush() after to apply and re-render.
+   * Call `flush()` after to apply and re-render.
    */
   scrollToItem(elementId: number, index: number, offsetInItem?: number | undefined | null): void
   /**
@@ -365,7 +370,12 @@ export declare class TestGpuiRenderer {
   getText(id: number): string | null
   /** Get the full tree as JSON for snapshot testing. */
   getTreeJson(): string
-  /** Tree JSON with last-paint bounds. Used by the automation locators. */
+  /**
+   * Tree JSON with last-paint bounds. Used by the automation locators.
+   * GPUI accessibility tree from the last painted frame.
+   */
+  advanceTime(milliseconds: number): void
+  getA11yTree(): string
   getAutomationTree(): string
   /** Last painted bounds for an element, or null if it was not painted. */
   getElementBounds(id: number): Array<number> | null

--- a/packages/vue/src/events.ts
+++ b/packages/vue/src/events.ts
@@ -5,8 +5,16 @@ export type GpuiEventHandlerValue = GpuiEventHandler | GpuiEventHandler[]
 
 type HandlerMap = Map<NativeNodeId, Map<string, GpuiEventHandlerValue>>
 
-const fallbackEventHandlers: HandlerMap = new Map()
-const rendererEventHandlers = new WeakMap<object, HandlerMap>()
+const eventStateKey = Symbol.for("gpui-native.vue.events")
+const eventState = (Reflect.get(globalThis, eventStateKey) as
+  | {
+      fallback: HandlerMap
+      renderers: WeakMap<object, HandlerMap>
+    }
+  | undefined) ?? { fallback: new Map(), renderers: new WeakMap() }
+Reflect.set(globalThis, eventStateKey, eventState)
+const fallbackEventHandlers = eventState.fallback
+const rendererEventHandlers = eventState.renderers
 
 export const EVENT_PROPS = [
   ["onToggleFile", "toggleFile"],
@@ -64,13 +72,14 @@ export function patchEvent(
   }
 }
 
-export function handleGpuiEvent(payload: EventPayload, renderer?: NativeRenderer): void {
+export function handleGpuiEvent(payload: EventPayload, renderer?: NativeRenderer): boolean {
   const handler = handlersFor(renderer).get(payload.elementId)?.get(payload.eventType)
   if (Array.isArray(handler)) {
     for (const callback of handler.slice()) callback(payload)
   } else {
     handler?.(payload)
   }
+  return handler !== undefined
 }
 
 export function subscribeRendererEvent(

--- a/packages/vue/src/native-addon.ts
+++ b/packages/vue/src/native-addon.ts
@@ -4,6 +4,7 @@ import type { GpuiRenderer as NativeGpuiRenderer } from "@gpui-native/core"
 
 import { handleGpuiEvent } from "./events.js"
 import type { NativeEventCallback, NativeRenderer } from "./native.js"
+import { reportRuntimeError } from "./runtime-errors.js"
 import type { EventPayload } from "./types.js"
 
 interface NativeModule {
@@ -60,8 +61,12 @@ export function createNativeRenderer(onEvent?: (event: EventPayload) => void): N
         return
       }
       if (event !== null) {
-        handleGpuiEvent(event, renderer)
-        onEvent?.(event)
+        try {
+          const delivered = handleGpuiEvent(event, renderer)
+          if (delivered || event.elementId === 0) onEvent?.(event)
+        } catch (error) {
+          reportRuntimeError(renderer, error)
+        }
       }
     }),
   )

--- a/packages/vue/src/native-testing.ts
+++ b/packages/vue/src/native-testing.ts
@@ -62,6 +62,8 @@ interface NativeTestRendererApi extends NativeRenderer {
   cycleDebugFrameOverlay(): string
   resetDebugFrameOverlayStats(): void
   getDebugFrameOverlayStats(): DebugFrameOverlayStats
+  advanceTime(milliseconds: number): void
+  getA11yTree(): string
   captureScreenshot(path: string): void
   clockPause(): number
   clockSet(nowMs: number): number
@@ -335,6 +337,17 @@ export class TestRenderer extends MutationRenderer implements NativeRenderer {
 
   getDebugFrameOverlayStats(): DebugFrameOverlayStats {
     return this.#native.getDebugFrameOverlayStats()
+  }
+
+  advanceTime(milliseconds: number): void {
+    this.#native.advanceTime(milliseconds)
+    this.dispatchNativeEvents()
+    this.#native.flush()
+  }
+
+  getA11yTree(): unknown {
+    this.flush()
+    return JSON.parse(this.#native.getA11yTree()) as unknown
   }
 
   captureScreenshot(path: string): void {

--- a/packages/vue/src/native.ts
+++ b/packages/vue/src/native.ts
@@ -46,6 +46,9 @@ export interface NativeRenderer {
   activateWindow?(): void
   setWindowTitle?(title: string): void
   focusElement?(elementId: NativeNodeId): void
+  focusNext?(): void
+  focusPrevious?(): void
+  setWindowKeyEvents?(keyDown: boolean, keyUp: boolean, eventId: number): void
   blur?(): void
   getSelectedText?(): string | null
   clearSelection?(): void

--- a/packages/vue/src/nodeOps.ts
+++ b/packages/vue/src/nodeOps.ts
@@ -255,7 +255,12 @@ export function createPatchProp(renderer: NativeRenderer) {
       return
     }
 
-    if (!BUILT_IN_TYPES.has(element.tag) || UNIVERSAL_PROPS.has(key)) {
+    if (
+      !BUILT_IN_TYPES.has(element.tag) ||
+      UNIVERSAL_PROPS.has(key) ||
+      key === "role" ||
+      key.startsWith("aria-")
+    ) {
       renderer.setCustomProp(element.id, key, serializeCustomProp(next))
     }
     setLocalProp(element, key, next)

--- a/packages/vue/src/renderer.ts
+++ b/packages/vue/src/renderer.ts
@@ -13,7 +13,21 @@ import { MemoryNativeRenderer, type NativeRenderer } from "./native.js"
 import { createNodeOps, createPatchProp } from "./nodeOps.js"
 import { createGpuiRoot, type GpuiContainer, type GpuiNode } from "./nodes.js"
 
-const rendererOwners = new WeakMap<NativeRenderer, symbol>()
+const rendererStateKey = Symbol.for("gpui-native.vue.renderers")
+const rendererState = (Reflect.get(globalThis, rendererStateKey) as
+  | {
+      owners: WeakMap<NativeRenderer, symbol>
+      ids: WeakMap<NativeRenderer, number>
+    }
+  | undefined) ?? { owners: new WeakMap(), ids: new WeakMap() }
+Reflect.set(globalThis, rendererStateKey, rendererState)
+const rendererOwners = rendererState.owners
+
+export function allocateRendererId(renderer: NativeRenderer): number {
+  const id = (rendererState.ids.get(renderer) ?? 0) + 1
+  rendererState.ids.set(renderer, id)
+  return id
+}
 
 export interface GpuiRendererHost {
   /** The caller-provided first-party Rust renderer (or memory renderer in tests). */
@@ -41,8 +55,7 @@ export function createGpuiRenderer(
 
   try {
     const renderer = wrapWithBatching(nativeRenderer)
-    let nextId = 0
-    const allocateId = (): number => ++nextId
+    const allocateId = (): number => allocateRendererId(nativeRenderer)
 
     // A native root div lets Vue fragments have multiple top-level host nodes.
     const rootId = allocateId()

--- a/packages/vue/src/runtime-core.ts
+++ b/packages/vue/src/runtime-core.ts
@@ -2,14 +2,23 @@ import {
   defineComponent,
   h,
   isVNode,
+  shallowRef,
+  onErrorCaptured,
+  onUnmounted,
   type App,
   type Component,
   type VNode,
 } from "@vue/runtime-core"
 
-import { clearEventHandlers, subscribeRendererEvent } from "./events.js"
+import {
+  clearEventHandlers,
+  subscribeRendererEvent,
+  registerEventHandler,
+  unregisterEventHandlers,
+} from "./events.js"
 import type { NativeRenderer } from "./native.js"
-import { createGpuiRenderer, type GpuiRendererHost } from "./renderer.js"
+import { createGpuiRenderer, allocateRendererId, type GpuiRendererHost } from "./renderer.js"
+import { listenForRuntimeErrors, reportRuntimeError } from "./runtime-errors.js"
 import type { EventPayload, WindowOptions } from "./types.js"
 
 export interface FrameLoop {
@@ -30,6 +39,8 @@ export interface GpuiWindowRoot extends GpuiRoot {
 export interface RenderOptions extends WindowOptions {
   renderer?: NativeRenderer
   frameMs?: number
+  onKeyDown?: (event: EventPayload) => void
+  onKeyUp?: (event: EventPayload) => void
 }
 
 export type DefaultRendererFactory = (onEvent?: (event: EventPayload) => void) => NativeRenderer
@@ -45,6 +56,7 @@ interface RenderSlot {
   host?: GpuiRendererHost
   root?: GpuiRoot
   loop?: FrameLoop
+  onEvent?: (event: EventPayload) => void
 }
 
 export function startFrameLoop(
@@ -109,10 +121,14 @@ export function startFrameLoop(
   const loop = (): void => {
     if (stopped) return
     const started = performance.now()
-    if (renderer.tick?.() === false) {
-      stop()
-      options.onTerminated?.()
-      return
+    try {
+      if (renderer.tick?.() === false) {
+        stop()
+        options.onTerminated?.()
+        return
+      }
+    } catch (error) {
+      reportRuntimeError(renderer, error)
     }
     timer = setTimeout(loop, Math.max(0, frameMs - (performance.now() - started)))
   }
@@ -129,17 +145,79 @@ export function createGpuiRuntime(createDefaultRenderer: DefaultRendererFactory,
     return created
   }
 
-  const rootComponent = (name: string, root: Component | VNode): Component =>
+  const rootComponent = (
+    name: string,
+    root: Component | VNode,
+    renderer: NativeRenderer,
+  ): Component =>
     defineComponent({
       name,
-      setup: () => () => (isVNode(root) ? root : h(root)),
+      setup() {
+        const failure = shallowRef<string>()
+        const showError = (error: unknown): void => {
+          failure.value = error instanceof Error ? (error.stack ?? error.message) : String(error)
+        }
+        const stop = listenForRuntimeErrors(renderer, showError)
+        onUnmounted(stop)
+        onErrorCaptured((error) => {
+          showError(error)
+          return false
+        })
+        return () =>
+          failure.value === undefined
+            ? isVNode(root)
+              ? root
+              : h(root)
+            : h(
+                "div",
+                {
+                  style: {
+                    width: "100%",
+                    height: "100%",
+                    padding: 20,
+                    background: "#240e16",
+                    color: "#ffccd5",
+                    overflow: "scroll",
+                  },
+                  role: "alert",
+                  "aria-label": "Application runtime error",
+                },
+                [
+                  h("text", { style: { fontWeight: 700 } }, "Application runtime error"),
+                  h("text", { style: { fontFamily: "monospace" } }, failure.value),
+                ],
+              )
+      },
     })
+
+  const bindKeys = (
+    renderer: NativeRenderer,
+    down: RenderOptions["onKeyDown"],
+    up: RenderOptions["onKeyUp"],
+  ): (() => void) => {
+    const id = allocateRendererId(renderer)
+    if (down !== undefined) registerEventHandler(id, "windowKeyDown", down, renderer)
+    if (up !== undefined) registerEventHandler(id, "windowKeyUp", up, renderer)
+    renderer.setWindowKeyEvents?.(down !== undefined, up !== undefined, id)
+    return () => {
+      unregisterEventHandlers(id, renderer)
+      renderer.setWindowKeyEvents?.(false, false, id)
+    }
+  }
 
   const render = (root: Component | VNode, options: RenderOptions = {}): GpuiRoot => {
     const slot = renderSlot()
-    const { renderer: injected, onEvent, debugFrameOverlay, frameMs, ...windowOptions } = options
+    const {
+      renderer: injected,
+      onEvent,
+      onKeyDown,
+      onKeyUp,
+      debugFrameOverlay,
+      frameMs,
+      ...windowOptions
+    } = options
     if (slot.renderer === undefined) {
-      slot.renderer = injected ?? createDefaultRenderer(onEvent)
+      slot.renderer = injected ?? createDefaultRenderer((event) => slot.onEvent?.(event))
       if (slot.renderer.isInitialized?.() !== true) slot.renderer.init?.(windowOptions)
       slot.host = createGpuiRenderer(slot.renderer)
     } else if (injected !== undefined && injected !== slot.renderer) {
@@ -152,8 +230,11 @@ export function createGpuiRuntime(createDefaultRenderer: DefaultRendererFactory,
       throw new Error("gpui-vue native host failed to initialize")
     }
     slot.root?.unmount()
+    if (onEvent === undefined) delete slot.onEvent
+    else slot.onEvent = onEvent
+    const unbindKeys = bindKeys(nativeRenderer, onKeyDown, onKeyUp)
     if (debugFrameOverlay !== undefined) nativeRenderer.setDebugFrameOverlay?.(debugFrameOverlay)
-    const app = host.mount(rootComponent("GpuiVueRoot", root))
+    const app = host.mount(rootComponent("GpuiVueRoot", root, nativeRenderer))
 
     let mounted = true
     const mountedRoot: GpuiRoot = {
@@ -163,9 +244,13 @@ export function createGpuiRuntime(createDefaultRenderer: DefaultRendererFactory,
       unmount(): void {
         if (!mounted) return
         mounted = false
+        unbindKeys()
         app.unmount()
         host.flushMutations()
-        if (slot.root === mountedRoot) delete slot.root
+        if (slot.root === mountedRoot) {
+          delete slot.root
+          delete slot.onEvent
+        }
       },
     }
     slot.root = mountedRoot
@@ -180,12 +265,21 @@ export function createGpuiRuntime(createDefaultRenderer: DefaultRendererFactory,
   }
 
   const createWindow = (root: Component | VNode, options: RenderOptions = {}): GpuiWindowRoot => {
-    const { renderer: injected, onEvent, debugFrameOverlay, frameMs, ...windowOptions } = options
+    const {
+      renderer: injected,
+      onEvent,
+      onKeyDown,
+      onKeyUp,
+      debugFrameOverlay,
+      frameMs,
+      ...windowOptions
+    } = options
     const nativeRenderer = injected ?? createDefaultRenderer(onEvent)
     if (nativeRenderer.isInitialized?.() !== true) nativeRenderer.init?.(windowOptions)
     if (debugFrameOverlay !== undefined) nativeRenderer.setDebugFrameOverlay?.(debugFrameOverlay)
     const host = createGpuiRenderer(nativeRenderer)
-    const app = host.mount(rootComponent("GpuiVueWindowRoot", root))
+    const unbindKeys = bindKeys(nativeRenderer, onKeyDown, onKeyUp)
+    const app = host.mount(rootComponent("GpuiVueWindowRoot", root, nativeRenderer))
     const loop =
       injected === undefined
         ? startFrameLoop(nativeRenderer, {
@@ -202,6 +296,7 @@ export function createGpuiRuntime(createDefaultRenderer: DefaultRendererFactory,
       unmount(): void {
         if (!mounted) return
         mounted = false
+        unbindKeys()
         app.unmount()
         host.flushMutations()
       },

--- a/packages/vue/src/runtime-errors.ts
+++ b/packages/vue/src/runtime-errors.ts
@@ -1,0 +1,22 @@
+import type { NativeRenderer } from "./native.js"
+
+const key = Symbol.for("gpui-native.vue.errors")
+const listeners =
+  (Reflect.get(globalThis, key) as WeakMap<NativeRenderer, (error: unknown) => void> | undefined) ??
+  new WeakMap<NativeRenderer, (error: unknown) => void>()
+Reflect.set(globalThis, key, listeners)
+
+export function reportRuntimeError(renderer: NativeRenderer, error: unknown): void {
+  console.error("[gpui-native] runtime error", error)
+  listeners.get(renderer)?.(error)
+}
+
+export function listenForRuntimeErrors(
+  renderer: NativeRenderer,
+  listener: (error: unknown) => void,
+): () => void {
+  listeners.set(renderer, listener)
+  return () => {
+    if (listeners.get(renderer) === listener) listeners.delete(renderer)
+  }
+}

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -171,7 +171,14 @@ export interface StyleDesc {
   bottom?: number
   left?: number
 
-  background?: string
+  background?:
+    | string
+    | {
+        type: "linear-gradient"
+        angle: number
+        stops: [{ color: string; position: number }, { color: string; position: number }]
+        colorSpace?: "srgb" | "oklab"
+      }
   backgroundColor?: string
   color?: string
   opacity?: number
@@ -196,6 +203,7 @@ export interface StyleDesc {
   lineHeight?: number
   whiteSpace?: "normal" | "nowrap"
   textOverflow?: "ellipsis" | "ellipsis-start"
+  textDecoration?: "underline" | "line-through" | "none"
   lineClamp?: number
 
   overflow?: string
@@ -334,6 +342,14 @@ export type HighlightMatch = GeneratedHighlightMatch
 export type GpuiEventHandler = (event: EventPayload) => void
 
 export interface HostProps {
+  role?: string
+  "aria-id"?: string
+  "aria-label"?: string
+  "aria-description"?: string
+  "aria-valuetext"?: string
+  "aria-expanded"?: boolean
+  "aria-selected"?: boolean
+  "aria-level"?: number
   /** Vue reconciliation key; never forwarded to the native element. */
   key?: PropertyKey
   /** Template/component ref; consumed by Vue and never forwarded. */

--- a/packages/vue/src/wasm-bindings.d.ts
+++ b/packages/vue/src/wasm-bindings.d.ts
@@ -17,6 +17,9 @@ declare module "@gpui-native/wasm" {
     activateWindow(): void
     setWindowTitle(title: string): void
     focusElement(elementId: number): void
+    focusNext(): void
+    focusPrevious(): void
+    setWindowKeyEvents(keyDown: boolean, keyUp: boolean, eventId: number): void
     blur(): void
     getSelectedText(): string | undefined
     clearSelection(): void

--- a/packages/vue/src/web-native.ts
+++ b/packages/vue/src/web-native.ts
@@ -3,6 +3,7 @@ import initWasm, { WebGpuiRenderer as WasmGpuiRenderer } from "@gpui-native/wasm
 import { handleGpuiEvent } from "./events.js"
 import { MutationRenderer } from "./mutation-renderer.js"
 import type { NativeNodeId, NativeRenderer } from "./native.js"
+import { reportRuntimeError } from "./runtime-errors.js"
 import type {
   AudioBufferState,
   DebugFrameOverlayMode,
@@ -102,6 +103,16 @@ export class WebNativeRenderer extends MutationRenderer implements NativeRendere
 
   focusElement(elementId: NativeNodeId): void {
     this.#wasm.focusElement(elementId)
+  }
+
+  focusNext(): void {
+    this.#wasm.focusNext()
+  }
+  focusPrevious(): void {
+    this.#wasm.focusPrevious()
+  }
+  setWindowKeyEvents(keyDown: boolean, keyUp: boolean, eventId: number): void {
+    this.#wasm.setWindowKeyEvents(keyDown, keyUp, eventId)
   }
 
   blur(): void {
@@ -278,8 +289,12 @@ export class WebNativeRenderer extends MutationRenderer implements NativeRendere
   #drainEvents(): void {
     const events = parseJson<EventPayload[]>(this.#wasm.drainEventsJson())
     for (const event of events) {
-      handleGpuiEvent(event, this)
-      this.#onEvent?.(event)
+      try {
+        const delivered = handleGpuiEvent(event, this)
+        if (delivered || event.elementId === 0) this.#onEvent?.(event)
+      } catch (error) {
+        reportRuntimeError(this, error)
+      }
     }
   }
 }

--- a/packages/vue/test/native-upstream.mts
+++ b/packages/vue/test/native-upstream.mts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { h } from "@vue/runtime-core"
+
+import { createTestRoot, hasNativeTestRenderer } from "../src/native-testing.js"
+
+if (!hasNativeTestRenderer) {
+  console.log("GPU parity smoke skipped: native test renderer is unavailable")
+  process.exit(0)
+}
+const root = createTestRoot({ width: 480, height: 360 })
+let clicks = 0
+let changed = ""
+let submitted = 0
+try {
+  root.render(
+    h("div", { style: { display: "flex", flexDirection: "column", width: 480 } }, [
+      h(
+        "div",
+        {
+          role: "button",
+          "aria-label": "Delete note",
+          onClick: () => clicks++,
+          style: { width: 100, height: 30 },
+        },
+        "Delete",
+      ),
+      h("text", {}, ["Hello ", "world"]),
+      h("img", { alt: "Missing image", style: { width: 100, height: 30 } }),
+      h("textarea", {
+        value: "hello",
+        onChange: (event: { value?: string }) => {
+          changed = event.value ?? ""
+        },
+        style: { width: 200, height: 70 },
+      }),
+    ]),
+  )
+  const dump = JSON.stringify(root.renderer.getA11yTree())
+  assert(dump.includes("Delete note"), "button label must reach GPUI accessibility")
+  assert(dump.includes("Hello world"), "interpolated text must share one accessible value")
+  assert(dump.includes("Missing image"), "empty image must retain its accessible label")
+  const container = root.host.root.children[0]!
+  assert(container.kind === "element")
+  const button = container.children[0]!
+  const bounds = root.renderer.getElementBounds(button.id)!
+  root.renderer.nativeSimulateClick(bounds[0]! + 5, bounds[1]! + 5)
+  assert.equal(clicks, 1)
+  const textarea = container.children[3]!
+  root.renderer.nativeSimulateKeystrokes(textarea.id, "end enter")
+  assert.equal(changed, "hello\n", "textarea Enter should insert a newline")
+
+  root.render(
+    h("textarea", {
+      value: "hello",
+      onSubmit: () => submitted++,
+      onChange: (event: { value?: string }) => {
+        changed = event.value ?? ""
+      },
+      style: { width: 200, height: 70 },
+    }),
+  )
+  const composer = root.host.root.children[0]!
+  root.renderer.nativeSimulateKeystrokes(composer.id, "enter")
+  assert.equal(submitted, 1)
+  root.renderer.nativeSimulateKeystrokes(composer.id, "shift-enter")
+  assert.equal(changed, "hello\n")
+  const output = mkdtempSync(join(tmpdir(), "gpui-parity-"))
+  try {
+    root.render(
+      h(
+        "text",
+        { style: { fontSize: 24, color: "white", textDecoration: "none" } },
+        "Decorated text",
+      ),
+    )
+    root.renderer.captureScreenshot(join(output, "plain.png"))
+    root.render(
+      h(
+        "text",
+        { style: { fontSize: 24, color: "white", textDecoration: "underline" } },
+        "Decorated text",
+      ),
+    )
+    root.renderer.captureScreenshot(join(output, "underline.png"))
+    assert(
+      !readFileSync(join(output, "plain.png")).equals(readFileSync(join(output, "underline.png"))),
+      "underline must change painted pixels",
+    )
+    root.render(h("div", { style: { width: 100, height: 100, background: "red" } }))
+    root.renderer.captureScreenshot(join(output, "solid.png"))
+    root.render(
+      h("div", {
+        style: {
+          width: 100,
+          height: 100,
+          background: {
+            type: "linear-gradient",
+            angle: 90,
+            stops: [
+              { color: "red", position: 0 },
+              { color: "blue", position: 1 },
+            ],
+          },
+        },
+      }),
+    )
+    root.renderer.captureScreenshot(join(output, "gradient.png"))
+    assert(
+      !readFileSync(join(output, "solid.png")).equals(readFileSync(join(output, "gradient.png"))),
+      "gradient must change painted pixels",
+    )
+  } finally {
+    rmSync(output, { recursive: true, force: true })
+  }
+  console.log("GPU parity smoke passed: accessibility, primary click, textarea newline and submit")
+} finally {
+  root.unmount()
+}

--- a/packages/vue/test/upstream.test.ts
+++ b/packages/vue/test/upstream.test.ts
@@ -1,0 +1,127 @@
+import { defineComponent, h, nextTick } from "@vue/runtime-core"
+import { describe, expect, it, vi } from "vitest"
+
+import { handleGpuiEvent } from "../src/events.js"
+import { MemoryNativeRenderer } from "../src/native.js"
+import { createGpuiRenderer } from "../src/renderer.js"
+import { createGpuiRuntime, startFrameLoop } from "../src/runtime-core.js"
+import { reportRuntimeError } from "../src/runtime-errors.js"
+import type { EventPayload } from "../src/types.js"
+
+const event = (elementId: number, eventType = "click"): EventPayload => ({ elementId, eventType })
+
+describe("upstream behavior in the Vue adapter", () => {
+  it("forwards and removes accessibility props and structured gradients", () => {
+    const renderer = new MemoryNativeRenderer()
+    const host = createGpuiRenderer(renderer)
+    const gradient = {
+      type: "linear-gradient",
+      angle: 90,
+      stops: [
+        { color: "red", position: 0 },
+        { color: "blue", position: 1 },
+      ],
+    }
+    host.render(
+      h("div", {
+        role: "button",
+        "aria-label": "Delete",
+        "aria-selected": false,
+        style: { background: gradient, textDecoration: "underline" },
+      }),
+    )
+    const id = host.root.children[0]!.id
+    expect(renderer.getCustomProp(id, "role")).toBe('"button"')
+    expect(renderer.getCustomProp(id, "aria-selected")).toBe("false")
+    expect(renderer.getTreeJson()).toContain("linear-gradient")
+    host.render(h("div"))
+    expect(renderer.getCustomProp(id, "role")).toBeNull()
+    expect(renderer.getCustomProp(id, "aria-label")).toBeNull()
+    host.destroy()
+  })
+
+  it("does not reuse node IDs or dispatch queued clicks into a replacement root", () => {
+    const renderer = new MemoryNativeRenderer()
+    const first = createGpuiRenderer(renderer)
+    first.render(h("div", { onClick: () => undefined }))
+    const oldId = first.root.children[0]!.id
+    first.destroy()
+    const click = vi.fn<(event: EventPayload) => void>()
+    const second = createGpuiRenderer(renderer)
+    second.render(h("div", { onClick: click }))
+    const newId = second.root.children[0]!.id
+    expect(newId).toBeGreaterThan(oldId)
+    handleGpuiEvent(event(oldId), renderer)
+    expect(click).not.toHaveBeenCalled()
+    handleGpuiEvent(event(newId), renderer)
+    expect(click).toHaveBeenCalledOnce()
+    second.destroy()
+  })
+
+  it("continues pumping after a frame error", async () => {
+    const renderer = new MemoryNativeRenderer()
+    renderer.requiresTick = () => true
+    let ticks = 0
+    renderer.tick = () => {
+      if (++ticks === 1) throw new Error("transient frame error")
+      return false
+    }
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const loop = startFrameLoop(renderer, { frameMs: 1 })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      expect(ticks).toBe(2)
+      expect(log).toHaveBeenCalledOnce()
+    } finally {
+      loop.stop()
+      log.mockRestore()
+    }
+  })
+
+  it("renders an error stack in the owning window", async () => {
+    const renderer = new MemoryNativeRenderer()
+    const runtime = createGpuiRuntime(() => renderer, "__gpuiUpstreamErrorTest")
+    const root = runtime.render(defineComponent({ setup: () => () => h("text", "Working") }), {
+      renderer,
+    })
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    try {
+      reportRuntimeError(renderer, new Error("handler exploded"))
+      await nextTick()
+      root.host.flushMutations()
+      expect(renderer.getAllText().join("\n")).toContain("handler exploded")
+      expect(renderer.getAllText()).toContain("Application runtime error")
+    } finally {
+      runtime.resetRender()
+      log.mockRestore()
+    }
+  })
+
+  it("rejects queued window key events after remount and disables them on unmount", () => {
+    class KeyRenderer extends MemoryNativeRenderer {
+      keyEvents: [boolean, boolean, number] = [false, false, 0]
+      setWindowKeyEvents(down: boolean, up: boolean, id: number): void {
+        this.keyEvents = [down, up, id]
+      }
+    }
+    const renderer = new KeyRenderer()
+    const runtime = createGpuiRuntime(() => renderer, "__gpuiUpstreamKeyTest")
+    const app = defineComponent({ setup: () => () => h("text", "Keys") })
+    const first = vi.fn<(event: EventPayload) => void>()
+    const second = vi.fn<(event: EventPayload) => void>()
+    try {
+      runtime.render(app, { renderer, onKeyDown: first })
+      const oldId = renderer.keyEvents[2]
+      const root = runtime.render(app, { renderer, onKeyDown: second })
+      handleGpuiEvent(event(oldId, "windowKeyDown"), renderer)
+      expect(first).not.toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+      handleGpuiEvent(event(renderer.keyEvents[2], "windowKeyDown"), renderer)
+      expect(second).toHaveBeenCalledOnce()
+      root.unmount()
+      expect(renderer.keyEvents.slice(0, 2)).toEqual([false, false])
+    } finally {
+      runtime.resetRender()
+    }
+  })
+})


### PR DESCRIPTION
The engine contained a mixture of GPUix ports without a recorded review checkpoint. This synchronizes the relevant missing behavior through GPUix `6b4be86952aa89cfe61bb573740aea33fef5c5c4` and pins GPUI to `1f9d1cd88656cf1759b0bdad32fa3e2df3c4b0b9`, while retaining the framework-neutral core and Vue adapter.

- Add native accessibility roles, ARIA fields and actions; gradients, text decoration, raster data URLs and desktop HTTP image loading.
- Fix virtualized text selection and drag autoscroll, coalesced bounded undo/redo, caret positioning/clipping, textarea Enter behavior, primary clicks, and live mouse dispatch.
- Give applications ownership of window keyboard handling and focus traversal; preserve event registrations and node identities across reloads; contain callback/frame errors and display Vue errors per window.
- Pick up nonblocking AppKit pumping and Windows DPI setup. Keep Pages on single-threaded WebAssembly with matching browser APIs.
- Regenerate and commit `packages/core/index.d.ts`, extend native GPU smoke coverage, and record incorporated commits, existing fixes, intentional differences, and application migration notes in `docs/upstream-sync.md`.

React state/reconciliation, mobile plans, and process-global exception interception are intentionally excluded. Tab traversal now requires an application key handler; textarea Enter inserts a newline unless `onSubmit` is registered. Existing Unicode selection, atomic batches, style caching, SVG support, and event-driven window lifecycle are preserved.

Validation on macOS: full `bun run check`; 39 JavaScript tests; 244 Rust tests; native build and load/close/reopen smoke; GPU accessibility, click, textarea and pixel-change smoke; Pages/WebAssembly build. Verified all 20 generated HTML asset references resolve under `/gpui-native/`, plus shared event registration and cleanup across Bun module reloads. Windows and Linux validation runs in CI.
