### PR TITLE
Fix white-on-white Windows GPU smoke fixture

### DIFF
--- a/packages/vue/test/native-upstream.mts
+++ b/packages/vue/test/native-upstream.mts
@@ -70,21 +70,21 @@ try {
   assert.equal(changed, "hello\n")
   const output = mkdtempSync(join(tmpdir(), "gpui-parity-"))
   try {
-    root.render(
-      h(
-        "text",
-        { style: { fontSize: 24, color: "white", textDecoration: "none" } },
-        "Decorated text",
-      ),
-    )
+    // Windows clears opaque windows to white. Own both colors so this test
+    // measures decorations rather than a platform's default clear color.
+    const decoratedText = (text: string, textDecoration: "none" | "underline") =>
+      h("div", { style: { width: 400, height: 80, padding: 8, background: "#182030" } }, [
+        h("text", { style: { fontSize: 24, color: "white", textDecoration } }, text),
+      ])
+    root.render(decoratedText("", "none"))
+    root.renderer.captureScreenshot(join(output, "empty.png"))
+    root.render(decoratedText("Decorated text", "none"))
     root.renderer.captureScreenshot(join(output, "plain.png"))
-    root.render(
-      h(
-        "text",
-        { style: { fontSize: 24, color: "white", textDecoration: "underline" } },
-        "Decorated text",
-      ),
+    assert(
+      !readFileSync(join(output, "empty.png")).equals(readFileSync(join(output, "plain.png"))),
+      "text must be visible against the explicit background",
     )
+    root.render(decoratedText("Decorated text", "underline"))
     root.renderer.captureScreenshot(join(output, "underline.png"))
     assert(
       !readFileSync(join(output, "plain.png")).equals(readFileSync(join(output, "underline.png"))),


### PR DESCRIPTION
The Windows GPU smoke test compared white text with and without an underline on an unspecified background. GPUI’s DirectX renderer clears opaque windows to white, so the foreground and underline were invisible and both screenshots matched.

Give the decoration fixture a fixed dark background and dimensions, then assert that adding text changes the blank fixture before checking the underline. The underline and gradient pixel assertions remain enabled on Windows.

Validation: reproduced the contrast failure locally by changing the fixture to white; the dark fixture passes native GPU smoke on macOS. Full quality checks, 39 JavaScript tests, 244 Rust tests and native build pass. Windows confirmation runs in CI.
